### PR TITLE
General backend type safety improvements and php code modernization

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+[*]
+charset = utf-8
+indent_style = tab
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[{package.json,webpack.config.js}]
+indent_style = space
+indent_size = 2

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -88,7 +88,7 @@ return [
 		['name' => 'Icon#getLocalIconList', 'url' => '/api/v2/icon/list', 'verb' => 'GET'],
 
 		//
-		['name' => 'Vault#preflighted_cors', 'url' => '/api/v2/{path}', 'verb' => 'OPTIONS', 'requirements' => array('path' => '.+')],
+		['name' => 'Vault#preflighted_cors', 'url' => '/api/v2/{path}', 'verb' => 'OPTIONS', 'requirements' => ['path' => '.+']],
 		//Internal API
 		['name' => 'Internal#remind', 'url' => '/api/internal/notifications/remind/{credential_id}', 'verb' => 'POST'],
 		['name' => 'Internal#read', 'url' => '/api/internal/notifications/read/{credential_id}', 'verb' => 'DELETE'],

--- a/composer.json
+++ b/composer.json
@@ -6,5 +6,12 @@
             "email": "brantje@gmail.com"
         }
     ],
-    "require": {}
+    "license": "AGPL-3.0-or-later",
+    "scripts": {
+        "rector:check": "rector --dry-run --clear-cache",
+        "rector:fix": "rector"
+    },
+    "require-dev": {
+        "rector/rector": "^2.1"
+    }
 }

--- a/lib/Activity.php
+++ b/lib/Activity.php
@@ -227,18 +227,15 @@ class Activity implements \OCP\Activity\IExtension {
 	 * @param string $type
 	 * @return string|false
 	 */
-	public function getTypeIcon($type) {
-		switch ($type) {
-			case self::TYPE_ITEM_ACTION:
-			case self::TYPE_ITEM_EXPIRED:
-				return 'icon-password';
-			case self::TYPE_ITEM_SHARED:
-				return 'icon-share';
-			case self::TYPE_ITEM_RENAMED:
-				return 'icon-rename';
-		}
-		return false;
-	}
+	public function getTypeIcon($type)
+    {
+        return match ($type) {
+            self::TYPE_ITEM_ACTION, self::TYPE_ITEM_EXPIRED => 'icon-password',
+            self::TYPE_ITEM_SHARED => 'icon-share',
+            self::TYPE_ITEM_RENAMED => 'icon-rename',
+            default => false,
+        };
+    }
 
 	/**
 	 * The extension can define the parameter grouping by returning the index as integer.

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -84,13 +84,9 @@ class Application extends App implements IBootstrap {
 
 		$context->registerSearchProvider(Provider::class);
 
-		$context->registerService(View::class, function () {
-			return new View('');
-		}, false);
+		$context->registerService(View::class, fn() => new View(''), false);
 
-		$context->registerService('isCLI', function () {
-			return \OC::$CLI;
-		});
+		$context->registerService('isCLI', fn() => \OC::$CLI);
 
 		$context->registerMiddleware(ShareMiddleware::class);
 		$context->registerMiddleware(APIMiddleware::class);
@@ -121,20 +117,16 @@ class Application extends App implements IBootstrap {
 		});
 
 
-		$context->registerService('CronService', function (ContainerInterface $c) {
-			return new CronService(
+		$context->registerService('CronService', fn(ContainerInterface $c) => new CronService(
 				$c->get(CredentialService::class),
 				$c->get(LoggerInterface::class),
 				$c->get(Utils::class),
 				$c->get(NotificationService::class),
 				$c->get(ActivityService::class),
 				$c->get(IDBConnection::class)
-			);
-		});
+			));
 
-		$context->registerService('Logger', function (ContainerInterface $c) {
-			return $c->get(ServerContainer::class)->getLogger();
-		});
+		$context->registerService('Logger', fn(ContainerInterface $c) => $c->get(ServerContainer::class)->getLogger());
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/BackgroundJob/ExpireCredentials.php
+++ b/lib/BackgroundJob/ExpireCredentials.php
@@ -45,7 +45,7 @@ class ExpireCredentials extends TimedJob {
 	public function __construct(
 		ITimeFactory $timeFactory,
 		protected IConfig $config,
-		private CronService $cronService,
+		private readonly CronService $cronService,
 	) {
         parent::__construct($timeFactory);
 

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -28,19 +28,17 @@ use OCP\IUserManager;
 
 
 class AdminController extends ApiController {
-	private $userId;
-
 	public function __construct(
 		$AppName,
 		IRequest $request,
-		$UserId,
-		private VaultService $vaultService,
-		private CredentialService $credentialService,
-		private FileService $fileService,
-		private CredentialRevisionService $revisionService,
-		private DeleteVaultRequestService $deleteVaultRequestService,
-		private IConfig $config,
-		private IUserManager $userManager,
+		private $userId,
+		private readonly VaultService $vaultService,
+		private readonly CredentialService $credentialService,
+		private readonly FileService $fileService,
+		private readonly CredentialRevisionService $revisionService,
+		private readonly DeleteVaultRequestService $deleteVaultRequestService,
+		private readonly IConfig $config,
+		private readonly IUserManager $userManager,
 	) {
 		parent::__construct(
 			$AppName,
@@ -48,7 +46,6 @@ class AdminController extends ApiController {
 			'GET, POST, DELETE, PUT, PATCH, OPTIONS',
 			'Authorization, Content-Type, Accept',
 			86400);
-		$this->userId = $UserId;
 
 	}
 
@@ -121,7 +118,7 @@ class AdminController extends ApiController {
 		$req = $this->deleteVaultRequestService->getDeleteRequestForVault($vault_guid);
 		try{
 			$vault = $this->vaultService->getByGuid($vault_guid, $requested_by);
-		} catch (\Exception $e){
+		} catch (\Exception){
 			//Ignore
 		}
 
@@ -175,7 +172,7 @@ class AdminController extends ApiController {
 		$result = false;
 		try {
 			$delete_request = $this->deleteVaultRequestService->getDeleteRequestForVault($vault_guid);
-		} catch (\Exception $exception){
+		} catch (\Exception){
 			// Ignore it
 		}
 

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -22,7 +22,6 @@ use OCA\PassmanNext\Service\VaultService;
 use OCA\PassmanNext\Utility\Utils;
 use OCP\AppFramework\ApiController;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IUserManager;
 
@@ -37,7 +36,6 @@ class AdminController extends ApiController {
 		private readonly FileService $fileService,
 		private readonly CredentialRevisionService $revisionService,
 		private readonly DeleteVaultRequestService $deleteVaultRequestService,
-		private readonly IConfig $config,
 		private readonly IUserManager $userManager,
 	) {
 		parent::__construct(

--- a/lib/Controller/CredentialController.php
+++ b/lib/Controller/CredentialController.php
@@ -28,17 +28,15 @@ use OCP\IRequest;
 
 
 class CredentialController extends ApiController {
-	private $userId;
-
 	public function __construct(
 		$AppName,
 		IRequest $request,
-		$userId,
-		private CredentialService $credentialService,
-		private ActivityService $activityService,
-		private CredentialRevisionService $credentialRevisionService,
-		private ShareService $sharingService,
-		private SettingsService $settings,
+		private $userId,
+		private readonly CredentialService $credentialService,
+		private readonly ActivityService $activityService,
+		private readonly CredentialRevisionService $credentialRevisionService,
+		private readonly ShareService $sharingService,
+		private readonly SettingsService $settings,
 	) {
 		parent::__construct(
 			$AppName,
@@ -46,7 +44,6 @@ class CredentialController extends ApiController {
 			'GET, POST, DELETE, PUT, PATCH, OPTIONS',
 			'Authorization, Content-Type, Accept',
 			86400);
-		$this->userId = $userId;
 	}
 
 
@@ -199,7 +196,7 @@ class CredentialController extends ApiController {
 
 		try {
 			$acl_list = $this->sharingService->getCredentialAclList($storedCredential->getGuid());
-		} catch (\Exception $exception) {
+		} catch (\Exception) {
 			// Just check if we have an acl list
 		}
 		if (!empty($acl_list)) {
@@ -264,7 +261,7 @@ class CredentialController extends ApiController {
 	public function deleteCredential($credential_guid) {
 		try {
 			$credential = $this->credentialService->getCredentialByGUID($credential_guid, $this->userId);
-		} catch (\Exception $e) {
+		} catch (\Exception) {
 			return new NotFoundJSONResponse();
 		}
 		if ($credential instanceof Credential) {
@@ -285,7 +282,7 @@ class CredentialController extends ApiController {
 	public function getRevision($credential_guid) {
 		try {
 			$credential = $this->credentialService->getCredentialByGUID($credential_guid);
-		} catch (\Exception $ex) {
+		} catch (\Exception) {
 			return new NotFoundJSONResponse();
 		}
 		// If the request was made by the owner of the credential
@@ -320,7 +317,7 @@ class CredentialController extends ApiController {
 		$revision = null;
 		try {
 			$revision = $this->credentialRevisionService->getRevision($revision_id);
-		} catch (\Exception $exception) {
+		} catch (\Exception) {
 			return new JSONResponse([]);
 		}
 

--- a/lib/Controller/CredentialController.php
+++ b/lib/Controller/CredentialController.php
@@ -143,8 +143,8 @@ class CredentialController extends ApiController {
 
 
 		if (!hash_equals($storedCredential->getUserId(), $this->userId)) {
-			$acl = $this->sharingService->getCredentialAclForUser($this->userId, $storedCredential->getGuid());
-			if ($acl->hasPermission(SharingACL::WRITE)) {
+			$sharingAcl = $this->sharingService->getACL($this->userId, $storedCredential->getGuid());
+			if ($sharingAcl->hasPermission(SharingACL::WRITE)) {
 				$credential['shared_key'] = $storedCredential->getSharedKey();
 			} else {
 				return new DataResponse(['msg' => 'Not authorized'], Http::STATUS_UNAUTHORIZED);
@@ -153,7 +153,7 @@ class CredentialController extends ApiController {
 				return new DataResponse(['msg' => 'Not authorized'], Http::STATUS_UNAUTHORIZED);
 			}
 
-			if (!$acl->hasPermission(SharingACL::FILES)) {
+			if (!$sharingAcl->hasPermission(SharingACL::FILES)) {
 				// what ever the client transmitted, if it has no files permission, the previous files content will be preserved
 				$credential['files'] = $storedCredential->getFiles();
 			}

--- a/lib/Controller/FileController.php
+++ b/lib/Controller/FileController.php
@@ -95,7 +95,7 @@ class FileController extends ApiController {
 		try {
 			$file = $this->fileService->getFile($file_id, $this->userId);
 		} catch (\Exception) {
-
+			// do just nothing when having problems getting the requested file
 		}
 		if ($file) {
 			if ($file_data) {

--- a/lib/Controller/FileController.php
+++ b/lib/Controller/FileController.php
@@ -18,14 +18,12 @@ use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 
 class FileController extends ApiController {
-	private $userId;
-
 	public function __construct(
 		$AppName,
 		IRequest $request,
-		$UserId,
-		private FileService $fileService,
-		private LoggerInterface $logger,
+		private $userId,
+		private readonly FileService $fileService,
+		private readonly LoggerInterface $logger,
 	) {
 		parent::__construct(
 			$AppName,
@@ -33,7 +31,6 @@ class FileController extends ApiController {
 			'GET, POST, DELETE, PUT, PATCH, OPTIONS',
 			'Authorization, Content-Type, Accept',
 			86400);
-		$this->userId = $UserId;
 	}
 
 
@@ -97,7 +94,7 @@ class FileController extends ApiController {
 	public function updateFile($file_id, $file_data, $filename) {
 		try {
 			$file = $this->fileService->getFile($file_id, $this->userId);
-		} catch (\Exception $doesNotExistException) {
+		} catch (\Exception) {
 
 		}
 		if ($file) {

--- a/lib/Controller/FileController.php
+++ b/lib/Controller/FileController.php
@@ -69,9 +69,9 @@ class FileController extends ApiController {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 */
-	public function deleteFiles($file_ids) {
+	public function deleteFiles(string $file_ids) {
 		$failed_file_ids = [];
-		if ($file_ids != null && !empty($file_ids)) {
+		if (!empty($file_ids)) {
 			$decoded_file_ids = json_decode($file_ids);
 			foreach ($decoded_file_ids as $file_id) {
 				try {

--- a/lib/Controller/InternalController.php
+++ b/lib/Controller/InternalController.php
@@ -45,7 +45,7 @@ class InternalController extends ApiController {
 		$credential = $this->credentialService->getCredentialById($credential_id, $this->userId);
 		if ($credential) {
 			$credential->setExpireTime(time() + (24 * 60 * 60));
-			$this->credentialService->upd($credential);
+			$this->credentialService->updateCredentialEntity($credential);
 
 			$this->notificationService->markNotificationOfCredentialAsProcessed($credential_id, $this->userId);
 		}
@@ -69,7 +69,7 @@ class InternalController extends ApiController {
 		$credential = $this->credentialService->getCredentialById($credential_id, $this->userId);
 		if ($credential) {
 			$credential->setExpireTime(0);
-			$this->credentialService->upd($credential);
+			$this->credentialService->updateCredentialEntity($credential);
 
 			$this->notificationService->markNotificationOfCredentialAsProcessed($credential_id, $this->userId);
 		}

--- a/lib/Controller/InternalController.php
+++ b/lib/Controller/InternalController.php
@@ -21,16 +21,14 @@ use OCP\IConfig;
 use OCP\IRequest;
 
 class InternalController extends ApiController {
-	private $userId;
-
 	public function __construct(
 		$AppName,
 		IRequest $request,
-		$UserId,
-		private CredentialService $credentialService,
-		private NotificationService $notificationService,
-		private IConfig $config,
-		private IAppManager $appManager,
+		private $userId,
+		private readonly CredentialService $credentialService,
+		private readonly NotificationService $notificationService,
+		private readonly IConfig $config,
+		private readonly IAppManager $appManager,
 	) {
 		parent::__construct(
 			$AppName,
@@ -38,7 +36,6 @@ class InternalController extends ApiController {
 			'GET, POST, DELETE, PUT, PATCH, OPTIONS',
 			'Authorization, Content-Type, Accept',
 			86400);
-		$this->userId = $UserId;
 	}
 
 	/**

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -24,8 +24,8 @@ class SettingsController extends ApiController {
 		$AppName,
 		IRequest $request,
 		private $userId,
-		private SettingsService $settings,
-		private IL10N $l,
+		private readonly SettingsService $settings,
+		private readonly IL10N $l,
 	) {
 		parent::__construct(
 			$AppName,

--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -18,7 +18,6 @@ use OCA\PassmanNext\Service\ActivityService;
 use OCA\PassmanNext\Service\CredentialService;
 use OCA\PassmanNext\Service\FileService;
 use OCA\PassmanNext\Service\NotificationService;
-use OCA\PassmanNext\Service\SettingsService;
 use OCA\PassmanNext\Service\ShareService;
 use OCA\PassmanNext\Service\VaultService;
 use OCA\PassmanNext\Utility\NotFoundJSONResponse;
@@ -28,7 +27,6 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\NotFoundResponse;
-use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUserManager;
 use OCP\Notification\IManager;
@@ -42,7 +40,6 @@ class ShareController extends ApiController {
 		$AppName,
 		IRequest $request,
 		private $userId,
-		private readonly IGroupManager $groupManager,
 		private readonly IUserManager $userManager,
 		private readonly ActivityService $activityService,
 		private readonly VaultService $vaultService,
@@ -50,7 +47,6 @@ class ShareController extends ApiController {
 		private readonly CredentialService $credentialService,
 		private readonly NotificationService $notificationService,
 		private readonly FileService $fileService,
-		private readonly SettingsService $settings,
 		private readonly IManager $manager,
 	) {
 		parent::__construct(
@@ -538,7 +534,7 @@ class ShareController extends ApiController {
 				$acl->setPermissions($permission);
 				return $this->shareService->updateCredentialACL($acl);
 			} catch (\Exception) {
-
+				// handled by the ($acl === null) condition below
 			}
 
 			if ($acl === null) {

--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -123,7 +123,7 @@ class ShareController extends ApiController {
 
 		$acl = null;
 		try {
-			$acl = $this->shareService->getCredentialAclForUser($first_vault['user_id'], $item_guid);
+			$acl = $this->shareService->getACL($first_vault['user_id'], $item_guid);
 		} catch (\Exception) {
 			// no need to catch this
 		}
@@ -207,7 +207,7 @@ class ShareController extends ApiController {
 		$acl = null;
 		$sr = null;
 		try {
-			$acl = $this->shareService->getCredentialAclForUser($user_id, $item_guid);
+			$acl = $this->shareService->getACL($user_id, $item_guid);
 		} catch (\Exception) {
 			// no need to handle this
 		}

--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -73,7 +73,7 @@ class ShareController extends ApiController {
 	public function createPublicShare($item_id, $item_guid, $permissions, $expire_timestamp, $expire_views) {
 		try {
 			$credential = $this->credentialService->getCredentialByGUID($item_guid);
-		} catch (\Exception $exception) {
+		} catch (\Exception) {
 			return new NotFoundResponse();
 		}
 
@@ -121,7 +121,7 @@ class ShareController extends ApiController {
 			if (count($shareRequests) > 0) {
 				return new JSONResponse(['error' => 'User got already pending requests']);
 			}
-		} catch (\Exception $exception) {
+		} catch (\Exception) {
 			// no need to catch this
 		}
 
@@ -212,14 +212,14 @@ class ShareController extends ApiController {
 		$sr = null;
 		try {
 			$acl = $this->shareService->getCredentialAclForUser($user_id, $item_guid);
-		} catch (\Exception $e) {
-
+		} catch (\Exception) {
+			// no need to handle this
 		}
 		try {
 			$shareRequests = $this->shareService->getPendingShareRequestsForCredential($item_guid, $user_id);
 			$sr = array_pop($shareRequests);
 		} catch (\Exception) {
-			// no need to catch this
+			// no need to handle this
 		}
 
 		if ($sr) {

--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -35,25 +35,23 @@ use OCP\Notification\IManager;
 
 
 class ShareController extends ApiController {
-	private $userId;
-
 	private $limit = 50;
 	private $offset = 0;
 
 	public function __construct(
 		$AppName,
 		IRequest $request,
-		$UserId,
-		private IGroupManager $groupManager,
-		private IUserManager $userManager,
-		private ActivityService $activityService,
-		private VaultService $vaultService,
-		private ShareService $shareService,
-		private CredentialService $credentialService,
-		private NotificationService $notificationService,
-		private FileService $fileService,
-		private SettingsService $settings,
-		private IManager $manager,
+		private $userId,
+		private readonly IGroupManager $groupManager,
+		private readonly IUserManager $userManager,
+		private readonly ActivityService $activityService,
+		private readonly VaultService $vaultService,
+		private readonly ShareService $shareService,
+		private readonly CredentialService $credentialService,
+		private readonly NotificationService $notificationService,
+		private readonly FileService $fileService,
+		private readonly SettingsService $settings,
+		private readonly IManager $manager,
 	) {
 		parent::__construct(
 			$AppName,
@@ -61,8 +59,6 @@ class ShareController extends ApiController {
 			'GET, POST, DELETE, PUT, PATCH, OPTIONS',
 			'Authorization, Content-Type, Accept',
 			86400);
-
-		$this->userId = $UserId;
 	}
 
 
@@ -83,7 +79,7 @@ class ShareController extends ApiController {
 
 		try {
 			$acl = $this->shareService->getACL(null, $item_guid);
-		} catch (\Exception $exception) {
+		} catch (\Exception) {
 			$acl = new SharingACL();
 		}
 
@@ -132,7 +128,7 @@ class ShareController extends ApiController {
 		$acl = null;
 		try {
 			$acl = $this->shareService->getCredentialAclForUser($first_vault['user_id'], $item_guid);
-		} catch (\Exception $exception) {
+		} catch (\Exception) {
 			// no need to catch this
 		}
 
@@ -147,7 +143,7 @@ class ShareController extends ApiController {
 				if (!in_array($vault->getTargetUserId(), $processed_users)) {
 					$target_user = $vault->getTargetUserId();
 					$notification = [
-						'from_user' => ucfirst($this->userId->getDisplayName()),
+						'from_user' => ucfirst((string) $this->userId->getDisplayName()),
 						'credential_label' => $credential->getLabel(),
 						'credential_id' => $credential->getId(),
 						'item_id' => $credential->getId(),
@@ -222,7 +218,7 @@ class ShareController extends ApiController {
 		try {
 			$shareRequests = $this->shareService->getPendingShareRequestsForCredential($item_guid, $user_id);
 			$sr = array_pop($shareRequests);
-		} catch (\Exception $e) {
+		} catch (\Exception) {
 			// no need to catch this
 		}
 
@@ -275,7 +271,7 @@ class ShareController extends ApiController {
 	public function savePendingRequest($item_guid, $target_vault_guid, $final_shared_key) {
 		try {
 			$sr = $this->shareService->getRequestByGuid($item_guid, $target_vault_guid);
-		} catch (\Exception $ex) {
+		} catch (\Exception) {
 			return new NotFoundResponse();
 		}
 
@@ -286,7 +282,7 @@ class ShareController extends ApiController {
 		$this->manager->markProcessed($notification);
 
 		$notification = [
-			'from_user' => ucfirst($this->userId->getDisplayName()),
+			'from_user' => ucfirst((string) $this->userId->getDisplayName()),
 			'credential_label' => $this->credentialService->getCredentialLabelById($sr->getItemId())->getLabel(),
 			'target_user' => $sr->getFromUserId(),
 			'req_id' => $sr->getId()
@@ -315,7 +311,7 @@ class ShareController extends ApiController {
 				$results[] = $result;
 			}
 			return new JSONResponse($results);
-		} catch (\Exception $ex) {
+		} catch (\Exception) {
 			return new NotFoundResponse();
 		}
 	}
@@ -329,7 +325,7 @@ class ShareController extends ApiController {
 	public function getRevisions($item_guid) {
 		try {
 			return new JSONResponse($this->shareService->getItemHistory($this->userId, $item_guid));
-		} catch (\Exception $ex) {
+		} catch (\Exception) {
 			return new NotFoundJSONResponse();
 		}
 	}
@@ -343,7 +339,7 @@ class ShareController extends ApiController {
 	public function getVaultItems($vault_guid) {
 		try {
 			return new JSONResponse($this->shareService->getSharedItems($this->userId->getUID(), $vault_guid));
-		} catch (\Exception $ex) {
+		} catch (\Exception) {
 			return new NotFoundResponse();
 		}
 	}
@@ -357,7 +353,7 @@ class ShareController extends ApiController {
 	public function getVaultAclEntries($vault_guid) {
 		try {
 			return new JSONResponse($this->shareService->getVaultAclList($this->userId->getUID(), $vault_guid));
-		} catch (\Exception $ex) {
+		} catch (\Exception) {
 			return new NotFoundResponse();
 		}
 	}
@@ -373,7 +369,7 @@ class ShareController extends ApiController {
 
 			$sr = $this->shareService->getShareRequestById($share_request_id);
 			$notification = [
-				'from_user' => ucfirst($this->userId->getDisplayName()),
+				'from_user' => ucfirst((string) $this->userId->getDisplayName()),
 				'credential_label' => $this->credentialService->getCredentialLabelById($sr->getItemId())->getLabel(),
 				'target_user' => $sr->getFromUserId(),
 				'req_id' => $sr->getId()
@@ -391,7 +387,7 @@ class ShareController extends ApiController {
 
 			$this->shareService->cleanItemRequestsForUser($sr);
 			return new JSONResponse(['result' => true]);
-		} catch (\Exception $ex) {
+		} catch (\Exception) {
 			return new NotFoundJSONResponse();
 		}
 	}
@@ -424,7 +420,7 @@ class ShareController extends ApiController {
 		try {
 			$credential = $this->shareService->getSharedItem(null, $credential_guid);
 			return new JSONResponse($credential);
-		} catch (\Exception $ex) {
+		} catch (\Exception) {
 			return new NotFoundJSONResponse();
 		}
 	}
@@ -450,7 +446,7 @@ class ShareController extends ApiController {
 			} else {
 				return new NotFoundResponse();
 			}
-		} catch (\Exception $ex) {
+		} catch (\Exception) {
 			return new JSONResponse([]);
 		}
 	}
@@ -467,7 +463,7 @@ class ShareController extends ApiController {
 	public function getFile($item_guid, $file_guid) {
 		try {
 			$credential = $this->credentialService->getCredentialByGUID($item_guid);
-		} catch (\Exception $e) {
+		} catch (\Exception) {
 			return new NotFoundJSONResponse();
 		}
 
@@ -497,7 +493,7 @@ class ShareController extends ApiController {
 	public function uploadFile($item_guid, $data, $filename, $mimetype, $size) {
 		try {
 			$credential = $this->credentialService->getCredentialByGUID($item_guid);
-		} catch (\Exception $e) {
+		} catch (\Exception) {
 			return new NotFoundJSONResponse();
 		}
 
@@ -532,7 +528,7 @@ class ShareController extends ApiController {
 	public function updateSharedCredentialACL($item_guid, $user_id, $permission) {
 		try {
 			$credential = $this->credentialService->getCredentialByGUID($item_guid);
-		} catch (\Exception $exception) {
+		} catch (\Exception) {
 			return new NotFoundJSONResponse();
 		}
 		if ($this->userId->getUID() === $credential->getUserId()) {
@@ -541,7 +537,7 @@ class ShareController extends ApiController {
 				$acl = $this->shareService->getACL($user_id, $item_guid);
 				$acl->setPermissions($permission);
 				return $this->shareService->updateCredentialACL($acl);
-			} catch (\Exception $exception) {
+			} catch (\Exception) {
 
 			}
 

--- a/lib/Controller/TranslationController.php
+++ b/lib/Controller/TranslationController.php
@@ -21,7 +21,7 @@ class TranslationController extends ApiController {
 	public function __construct(
 		$AppName,
 		IRequest $request,
-		private IL10N $trans,
+		private readonly IL10N $trans,
 	) {
 		parent::__construct(
 			$AppName,

--- a/lib/Controller/VaultController.php
+++ b/lib/Controller/VaultController.php
@@ -25,18 +25,16 @@ use Psr\Log\LoggerInterface;
 
 
 class VaultController extends ApiController {
-	private $userId;
-
 	public function __construct(
 		$AppName,
 		IRequest $request,
-		$UserId,
-		private VaultService $vaultService,
-		private CredentialService $credentialService,
-		private DeleteVaultRequestService $deleteVaultRequestService,
-		private SettingsService $settings,
-		private FileService $fileService,
-		private LoggerInterface $logger,
+		private $userId,
+		private readonly VaultService $vaultService,
+		private readonly CredentialService $credentialService,
+		private readonly DeleteVaultRequestService $deleteVaultRequestService,
+		private readonly SettingsService $settings,
+		private readonly FileService $fileService,
+		private readonly LoggerInterface $logger,
 	) {
 		parent::__construct(
 			$AppName,
@@ -44,7 +42,6 @@ class VaultController extends ApiController {
 			'GET, POST, DELETE, PUT, PATCH, OPTIONS',
 			'Authorization, Content-Type, Accept',
 			86400);
-		$this->userId = $UserId;
 	}
 
 	/**
@@ -95,7 +92,7 @@ class VaultController extends ApiController {
 		$vault = null;
 		try {
 			$vault = $this->vaultService->getByGuid($vault_guid, $this->userId);
-		} catch (\Exception $e) {
+		} catch (\Exception) {
 			return new NotFoundJSONResponse();
 		}
 		$result = [];
@@ -146,8 +143,8 @@ class VaultController extends ApiController {
 		$vault = null;
 		try {
 			$vault = $this->vaultService->getByGuid($vault_guid, $this->userId);
-		} catch (\Exception $e) {
-			// No need to catch the execption
+		} catch (\Exception) {
+			// No need to catch the exception
 		}
 
 		if ($vault) {
@@ -181,7 +178,7 @@ class VaultController extends ApiController {
 					}
 				}
 			}
-		} catch (\Exception $e) {
+		} catch (\Exception) {
 			return new NotFoundJSONResponse();
 		}
 

--- a/lib/Controller/VaultController.php
+++ b/lib/Controller/VaultController.php
@@ -14,8 +14,6 @@ namespace OCA\PassmanNext\Controller;
 use OCA\PassmanNext\Db\Credential;
 use OCA\PassmanNext\Service\CredentialService;
 use OCA\PassmanNext\Service\DeleteVaultRequestService;
-use OCA\PassmanNext\Service\FileService;
-use OCA\PassmanNext\Service\SettingsService;
 use OCA\PassmanNext\Service\VaultService;
 use OCA\PassmanNext\Utility\NotFoundJSONResponse;
 use OCP\AppFramework\ApiController;
@@ -32,8 +30,6 @@ class VaultController extends ApiController {
 		private readonly VaultService $vaultService,
 		private readonly CredentialService $credentialService,
 		private readonly DeleteVaultRequestService $deleteVaultRequestService,
-		private readonly SettingsService $settings,
-		private readonly FileService $fileService,
 		private readonly LoggerInterface $logger,
 	) {
 		parent::__construct(

--- a/lib/Db/CredentialMapper.php
+++ b/lib/Db/CredentialMapper.php
@@ -111,7 +111,7 @@ class CredentialMapper extends QBMapper {
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getCredentialById(int $credential_id, string $user_id = null): Credential {
+	public function getCredentialById(int $credential_id, ?string $user_id = null): Credential {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -235,7 +235,7 @@ class CredentialMapper extends QBMapper {
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getCredentialByGUID(string $credential_guid, string $user_id = null): Credential {
+	public function getCredentialByGUID(string $credential_guid, ?string $user_id = null): Credential {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)

--- a/lib/Db/CredentialMapper.php
+++ b/lib/Db/CredentialMapper.php
@@ -25,12 +25,15 @@ namespace OCA\PassmanNext\Db;
 
 use OCA\PassmanNext\Utility\Utils;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Db\Entity;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
+/**
+ * @template-extends QBMapper<Credential>
+ */
 class CredentialMapper extends QBMapper {
 	const TABLE_NAME = 'passman_credentials';
 
@@ -47,9 +50,9 @@ class CredentialMapper extends QBMapper {
 	 *
 	 * @param string $vault_id
 	 * @param string $user_id
-	 * @return Entity[]
+	 * @return Credential[]
 	 */
-	public function getCredentialsByVaultId(string $vault_id, string $user_id) {
+	public function getCredentialsByVaultId(string $vault_id, string $user_id): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -59,14 +62,15 @@ class CredentialMapper extends QBMapper {
 		return $this->findEntities($qb);
 	}
 
-    /**
-     * Get a random credential from a vault
-     *
-     * @param string $vault_id
-     * @param string $user_id
-     * @return Credential[]
-     */
-	public function getRandomCredentialByVaultId(string $vault_id, string $user_id): array {
+	/**
+	 * Get a random credential from a vault
+	 *
+	 * @param string $vault_id
+	 * @param string $user_id
+	 * @return Credential
+	 * @throws Exception
+	 */
+	public function getRandomCredentialByVaultId(string $vault_id, string $user_id): Credential {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -76,18 +80,18 @@ class CredentialMapper extends QBMapper {
 			->setMaxResults(20);
 
 		$entities = $this->findEntities($qb);
-		$count = count($entities) - 1;
+		$maxEntitiesIndex = count($entities) - 1;
 
-		return array_splice($entities, rand(0, $count), 1);
+		return $entities[rand(0, $maxEntitiesIndex)];
 	}
 
 	/**
 	 * Get expired credentials
 	 *
 	 * @param int $timestamp
-	 * @return Entity[]
+	 * @return Credential[]
 	 */
-	public function getExpiredCredentials(int $timestamp) {
+	public function getExpiredCredentials(int $timestamp): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -98,16 +102,16 @@ class CredentialMapper extends QBMapper {
 	}
 
 	/**
-	 * Get an credential by id.
+	 * Get a credential by id.
 	 * Optional user id
 	 *
 	 * @param int $credential_id
 	 * @param string|null $user_id
-	 * @return Entity
+	 * @return Credential
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getCredentialById(int $credential_id, string $user_id = null) {
+	public function getCredentialById(int $credential_id, string $user_id = null): Credential {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -124,11 +128,11 @@ class CredentialMapper extends QBMapper {
 	 * Get credential label by id
 	 *
 	 * @param int $credential_id
-	 * @return Entity
+	 * @return Credential partial Credential, containing only 'id' and 'label'
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getCredentialLabelById(int $credential_id) {
+	public function getCredentialLabelById(int $credential_id): Credential {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select(['id', 'label'])
 			->from(self::TABLE_NAME)
@@ -143,7 +147,7 @@ class CredentialMapper extends QBMapper {
 	 * @param $raw_credential
 	 * @return Credential
 	 */
-	public function create($raw_credential) {
+	public function create($raw_credential): Credential {
 		$credential = new Credential();
 
 		$credential->setGuid($this->utils->GUID());
@@ -174,13 +178,13 @@ class CredentialMapper extends QBMapper {
 	}
 
 	/**
-	 * @param $raw_credential array An array containing all the credential fields
-	 * @param $useRawUser bool
-	 * @return Credential|Entity The updated credential
+	 * @param array $raw_credential An array containing all the credential fields
+	 * @param bool $useRawUser
+	 * @return Credential The updated credential
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function updateCredential($raw_credential, bool $useRawUser) {
+	public function updateCredential(array $raw_credential, bool $useRawUser): Credential {
 		$original = $this->getCredentialByGUID($raw_credential['guid']);
 		$uid = ($useRawUser) ? $raw_credential['user_id'] : $original->getUserId();
 
@@ -214,11 +218,11 @@ class CredentialMapper extends QBMapper {
 		return parent::update($credential);
 	}
 
-	public function deleteCredential(Credential $credential) {
+	public function deleteCredential(Credential $credential): Credential {
 		return $this->delete($credential);
 	}
 
-	public function upd(Credential $credential) {
+	public function upd(Credential $credential): void {
 		$this->update($credential);
 	}
 
@@ -227,11 +231,11 @@ class CredentialMapper extends QBMapper {
 	 *
 	 * @param string $credential_guid
 	 * @param string|null $user_id
-	 * @return Entity
+	 * @return Credential
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getCredentialByGUID(string $credential_guid, string $user_id = null) {
+	public function getCredentialByGUID(string $credential_guid, string $user_id = null): Credential {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)

--- a/lib/Db/CredentialMapper.php
+++ b/lib/Db/CredentialMapper.php
@@ -36,7 +36,7 @@ class CredentialMapper extends QBMapper {
 
 	public function __construct(
 		IDBConnection $db,
-		private Utils $utils,
+		private readonly Utils $utils,
 	) {
 		parent::__construct($db, self::TABLE_NAME);
 	}
@@ -59,14 +59,14 @@ class CredentialMapper extends QBMapper {
 		return $this->findEntities($qb);
 	}
 
-	/**
-	 * Get a random credential from a vault
-	 *
-	 * @param string $vault_id
-	 * @param string $user_id
-	 * @return Credential[]
-	 */
-	public function getRandomCredentialByVaultId(string $vault_id, string $user_id) {
+    /**
+     * Get a random credential from a vault
+     *
+     * @param string $vault_id
+     * @param string $user_id
+     * @return Credential[]
+     */
+	public function getRandomCredentialByVaultId(string $vault_id, string $user_id): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -78,9 +78,7 @@ class CredentialMapper extends QBMapper {
 		$entities = $this->findEntities($qb);
 		$count = count($entities) - 1;
 
-		/** @var Credential[] $entity */
-		$entity = array_splice($entities, rand(0, $count), 1);
-		return $entity;
+		return array_splice($entities, rand(0, $count), 1);
 	}
 
 	/**

--- a/lib/Db/CredentialRevisionMapper.php
+++ b/lib/Db/CredentialRevisionMapper.php
@@ -33,11 +33,9 @@ use OCP\IDBConnection;
 
 class CredentialRevisionMapper extends QBMapper {
 	const TABLE_NAME = 'passman_revisions';
-	private Utils $utils;
 
-	public function __construct(IDBConnection $db, Utils $utils) {
+	public function __construct(IDBConnection $db, private readonly Utils $utils) {
 		parent::__construct($db, self::TABLE_NAME);
-		$this->utils = $utils;
 	}
 
 

--- a/lib/Db/CredentialRevisionMapper.php
+++ b/lib/Db/CredentialRevisionMapper.php
@@ -25,12 +25,14 @@ namespace OCA\PassmanNext\Db;
 
 use OCA\PassmanNext\Utility\Utils;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Db\Entity;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
+/**
+ * @template-extends QBMapper<CredentialRevision>
+ */
 class CredentialRevisionMapper extends QBMapper {
 	const TABLE_NAME = 'passman_revisions';
 
@@ -44,9 +46,9 @@ class CredentialRevisionMapper extends QBMapper {
 	 *
 	 * @param int $credential_id
 	 * @param string|null $user_id
-	 * @return Entity[]
+	 * @return CredentialRevision[]
 	 */
-	public function getRevisions(int $credential_id, string $user_id = null) {
+	public function getRevisions(int $credential_id, string $user_id = null): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -62,11 +64,11 @@ class CredentialRevisionMapper extends QBMapper {
 	/**
 	 * @param int $revision_id
 	 * @param string|null $user_id
-	 * @return Entity
+	 * @return CredentialRevision
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getRevision(int $revision_id, string $user_id = null) {
+	public function getRevision(int $revision_id, string $user_id = null): CredentialRevision {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -81,13 +83,13 @@ class CredentialRevisionMapper extends QBMapper {
 
 	/**
 	 * Create a revision
-	 * @param $credential
-	 * @param $userId
-	 * @param $credential_id
-	 * @param $edited_by
+	 * @param mixed $credential
+	 * @param string $userId
+	 * @param int $credential_id
+	 * @param string $edited_by
 	 * @return CredentialRevision
 	 */
-	public function create($credential, $userId, $credential_id, $edited_by) {
+	public function create(mixed $credential, string $userId, int $credential_id, string $edited_by): CredentialRevision {
 		$revision = new CredentialRevision();
 		$revision->setGuid($this->utils->GUID());
 		$revision->setUserId($userId);
@@ -101,11 +103,11 @@ class CredentialRevisionMapper extends QBMapper {
 
 	/**
 	 * Delete a revision
-	 * @param $revision_id
-	 * @param $user_id
+	 * @param int $revision_id
+	 * @param string $user_id
 	 * @return CredentialRevision
 	 */
-	public function deleteRevision($revision_id, $user_id) {
+	public function deleteRevision(int $revision_id, string $user_id): CredentialRevision {
 		$revision = new CredentialRevision();
 		$revision->setId($revision_id);
 		$revision->setUserId($user_id);

--- a/lib/Db/CredentialRevisionMapper.php
+++ b/lib/Db/CredentialRevisionMapper.php
@@ -48,7 +48,7 @@ class CredentialRevisionMapper extends QBMapper {
 	 * @param string|null $user_id
 	 * @return CredentialRevision[]
 	 */
-	public function getRevisions(int $credential_id, string $user_id = null): array {
+	public function getRevisions(int $credential_id, ?string $user_id = null): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -68,7 +68,7 @@ class CredentialRevisionMapper extends QBMapper {
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getRevision(int $revision_id, string $user_id = null): CredentialRevision {
+	public function getRevision(int $revision_id, ?string $user_id = null): CredentialRevision {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)

--- a/lib/Db/DeleteVaultRequestMapper.php
+++ b/lib/Db/DeleteVaultRequestMapper.php
@@ -25,12 +25,14 @@ namespace OCA\PassmanNext\Db;
 
 
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Db\Entity;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
+/**
+ * @template-extends QBMapper<DeleteVaultRequest>
+ */
 class DeleteVaultRequestMapper extends QBMapper {
 	const TABLE_NAME = 'passman_delete_vault_request';
 
@@ -41,17 +43,17 @@ class DeleteVaultRequestMapper extends QBMapper {
 	/**
 	 * Create a new enty in the db
 	 * @param DeleteVaultRequest $request
-	 * @return Entity
+	 * @return DeleteVaultRequest
 	 */
-	public function createRequest(DeleteVaultRequest $request) {
+	public function createRequest(DeleteVaultRequest $request): DeleteVaultRequest {
 		return $this->insert($request);
 	}
 
 	/**
 	 * Get all delete requests
-	 * @return Entity[]
+	 * @return DeleteVaultRequest[]
 	 */
-	public function getDeleteRequests() {
+	public function getDeleteRequests(): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME);
@@ -62,11 +64,11 @@ class DeleteVaultRequestMapper extends QBMapper {
 	/**
 	 * Get request for a vault guid
 	 * @param string $vault_guid
-	 * @return Entity
+	 * @return DeleteVaultRequest
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getDeleteRequestsForVault(string $vault_guid) {
+	public function getDeleteRequestsForVault(string $vault_guid): DeleteVaultRequest {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -80,8 +82,7 @@ class DeleteVaultRequestMapper extends QBMapper {
 	 * @param DeleteVaultRequest $request Request to delete
 	 * @return DeleteVaultRequest         The deleted request
 	 */
-	public function removeDeleteVaultRequest(DeleteVaultRequest $request) {
+	public function removeDeleteVaultRequest(DeleteVaultRequest $request): DeleteVaultRequest {
 		return $this->delete($request);
 	}
-
 }

--- a/lib/Db/FileMapper.php
+++ b/lib/Db/FileMapper.php
@@ -26,12 +26,14 @@ namespace OCA\PassmanNext\Db;
 
 use OCA\PassmanNext\Utility\Utils;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Db\Entity;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
+/**
+ * @template-extends QBMapper<File>
+ */
 class FileMapper extends QBMapper {
 	const TABLE_NAME = 'passman_files';
 
@@ -46,11 +48,11 @@ class FileMapper extends QBMapper {
 	/**
 	 * @param int $file_id
 	 * @param string|null $user_id
-	 * @return Entity
+	 * @return File
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getFile(int $file_id, string $user_id = null) {
+	public function getFile(int $file_id, string $user_id = null): File {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -66,11 +68,11 @@ class FileMapper extends QBMapper {
 	/**
 	 * @param string $file_guid
 	 * @param string|null $user_id
-	 * @return Entity
+	 * @return File
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getFileByGuid(string $file_guid, string $user_id = null) {
+	public function getFileByGuid(string $file_guid, string $user_id = null): File {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -84,11 +86,11 @@ class FileMapper extends QBMapper {
 	}
 
 	/**
-	 * @param $file_raw
-	 * @param $userId
+	 * @param array|File $file_raw
+	 * @param string $userId
 	 * @return File
 	 */
-	public function create($file_raw, $userId) {
+	public function create(array|File $file_raw, string $userId): File {
 		$file = new File();
 		$file->setGuid($this->utils->GUID());
 		$file->setUserId($userId);
@@ -106,9 +108,9 @@ class FileMapper extends QBMapper {
 	 *
 	 * @param int $file_id
 	 * @param string $userId
-	 * @return File|Entity
+	 * @return File
 	 */
-	public function deleteFile(int $file_id, string $userId) {
+	public function deleteFile(int $file_id, string $userId): File {
 		$file = new File();
 		$file->setId($file_id);
 		$file->setUserId($userId);
@@ -116,19 +118,19 @@ class FileMapper extends QBMapper {
 	}
 
 	/**
-	 * Uodate file
+	 * Update file
 	 * @param File $file
 	 * @return File
 	 */
-	public function updateFile(File $file) {
+	public function updateFile(File $file): File {
 		return $this->update($file);
 	}
 
 	/**
 	 * @param string $user_id
-	 * @return Entity[]
+	 * @return File[] array of incomplete File objects, containing only the guid
 	 */
-	public function getFileGuidsFromUser(string $user_id) {
+	public function getFileGuidsFromUser(string $user_id): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('guid')
 			->from(self::TABLE_NAME)

--- a/lib/Db/FileMapper.php
+++ b/lib/Db/FileMapper.php
@@ -52,7 +52,7 @@ class FileMapper extends QBMapper {
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getFile(int $file_id, string $user_id = null): File {
+	public function getFile(int $file_id, ?string $user_id = null): File {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -72,7 +72,7 @@ class FileMapper extends QBMapper {
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getFileByGuid(string $file_guid, string $user_id = null): File {
+	public function getFileByGuid(string $file_guid, ?string $user_id = null): File {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)

--- a/lib/Db/FileMapper.php
+++ b/lib/Db/FileMapper.php
@@ -37,7 +37,7 @@ class FileMapper extends QBMapper {
 
 	public function __construct(
 		IDBConnection $db,
-		private Utils $utils,
+		private readonly Utils $utils,
 	) {
 		parent::__construct($db, self::TABLE_NAME);
 	}

--- a/lib/Db/ShareRequestMapper.php
+++ b/lib/Db/ShareRequestMapper.php
@@ -25,14 +25,15 @@ namespace OCA\PassmanNext\Db;
 
 
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Db\Entity;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\DB\Exception;
-use OCP\DB\IResult;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
+/**
+ * @template-extends QBMapper<ShareRequest>
+ */
 class ShareRequestMapper extends QBMapper {
 	const TABLE_NAME = 'passman_share_request';
 
@@ -42,9 +43,9 @@ class ShareRequestMapper extends QBMapper {
 
 	/**
 	 * @param ShareRequest $request
-	 * @return ShareRequest|Entity
+	 * @return ShareRequest
 	 */
-	public function createRequest(ShareRequest $request) {
+	public function createRequest(ShareRequest $request): ShareRequest {
 		return $this->insert($request);
 	}
 
@@ -53,11 +54,11 @@ class ShareRequestMapper extends QBMapper {
 	 *
 	 * @param string $item_guid
 	 * @param string $target_vault_guid
-	 * @return Entity
+	 * @return ShareRequest
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getRequestByItemAndVaultGuid(string $item_guid, string $target_vault_guid) {
+	public function getRequestByItemAndVaultGuid(string $item_guid, string $target_vault_guid): ShareRequest {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -71,7 +72,7 @@ class ShareRequestMapper extends QBMapper {
 	 * Get shared items for the given item_guid
 	 *
 	 * @param string $item_guid
-	 * @return Entity[]
+	 * @return ShareRequest[]
 	 * @throws Exception
 	 */
 	public function getRequestsByItemGuid(string $item_guid): array {
@@ -91,10 +92,10 @@ class ShareRequestMapper extends QBMapper {
 	 *
 	 * @param int $item_id
 	 * @param string $target_user_id
-	 * @return int|IResult
+	 * @return int
 	 * @throws Exception
 	 */
-	public function cleanItemRequestsForUser(int $item_id, string $target_user_id) {
+	public function cleanItemRequestsForUser(int $item_id, string $target_user_id): int {
 		$qb = $this->db->getQueryBuilder();
 		return $qb->delete(self::TABLE_NAME)
 			->where($qb->expr()->eq('item_id', $qb->createNamedParameter($item_id, IQueryBuilder::PARAM_INT)))
@@ -106,9 +107,9 @@ class ShareRequestMapper extends QBMapper {
 	 * Obtains all pending share requests for the given user ID
 	 *
 	 * @param string $user_id
-	 * @return Entity[]
+	 * @return ShareRequest[]
 	 */
-	public function getUserPendingRequests(string $user_id) {
+	public function getUserPendingRequests(string $user_id): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -122,19 +123,19 @@ class ShareRequestMapper extends QBMapper {
 	 * @param ShareRequest $shareRequest Request to delete
 	 * @return ShareRequest                 The deleted request
 	 */
-	public function deleteShareRequest(ShareRequest $shareRequest) {
+	public function deleteShareRequest(ShareRequest $shareRequest): ShareRequest {
 		return $this->delete($shareRequest);
 	}
 
 	/**
-	 * Gets a share request by it's unique incremental id
+	 * Gets a share request by its unique incremental id
 	 *
 	 * @param int $id
-	 * @return Entity
+	 * @return ShareRequest
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getShareRequestById(int $id) {
+	public function getShareRequestById(int $id): ShareRequest {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -147,9 +148,9 @@ class ShareRequestMapper extends QBMapper {
 	 * Gets all share requests by a given item GUID
 	 *
 	 * @param string $item_guid
-	 * @return Entity[]
+	 * @return ShareRequest[]
 	 */
-	public function getShareRequestsByItemGuid(string $item_guid) {
+	public function getShareRequestsByItemGuid(string $item_guid): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -163,7 +164,7 @@ class ShareRequestMapper extends QBMapper {
 	 * @param ShareRequest $shareRequest
 	 * @return ShareRequest
 	 */
-	public function updateShareRequest(ShareRequest $shareRequest) {
+	public function updateShareRequest(ShareRequest $shareRequest): ShareRequest {
 		return $this->update($shareRequest);
 	}
 
@@ -172,9 +173,9 @@ class ShareRequestMapper extends QBMapper {
 	 *
 	 * @param string $item_guid
 	 * @param string $user_id
-	 * @return Entity[]
+	 * @return ShareRequest[]
 	 */
-	public function getPendingShareRequests(string $item_guid, string $user_id) {
+	public function getPendingShareRequests(string $item_guid, string $user_id): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -190,10 +191,10 @@ class ShareRequestMapper extends QBMapper {
 	 * @param string $item_guid The item for which to update the requests
 	 * @param string $user_id The user for which to update the requests
 	 * @param int $permissions The new permissions to apply
-	 * @return int|IResult
+	 * @return int
 	 * @throws Exception
 	 */
-	public function updatePendingRequestPermissions(string $item_guid, string $user_id, int $permissions) {
+	public function updatePendingRequestPermissions(string $item_guid, string $user_id, int $permissions): int {
 		$qb = $this->db->getQueryBuilder();
 		return $qb->update(self::TABLE_NAME)
 			->set('permissions', $qb->createNamedParameter($permissions, IQueryBuilder::PARAM_INT))

--- a/lib/Db/ShareRequestMapper.php
+++ b/lib/Db/ShareRequestMapper.php
@@ -74,8 +74,8 @@ class ShareRequestMapper extends QBMapper {
 	 * @return Entity[]
 	 * @throws Exception
 	 */
-	public function getRequestsByItemGuid(string $item_guid) {
-		if (strtolower($this->db->getDatabasePlatform()->getName()) === 'mysql') {
+	public function getRequestsByItemGuid(string $item_guid): array {
+		if ($this->db->getDatabaseProvider() === IDBConnection::PLATFORM_MYSQL) {
 			$this->db->executeQuery("SET sql_mode = '';");
 		}
 		$qb = $this->db->getQueryBuilder();

--- a/lib/Db/SharingACLMapper.php
+++ b/lib/Db/SharingACLMapper.php
@@ -25,12 +25,14 @@ namespace OCA\PassmanNext\Db;
 
 
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Db\Entity;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
+/**
+ * @template-extends QBMapper<SharingACL>
+ */
 class SharingACLMapper extends QBMapper {
 	const TABLE_NAME = 'passman_sharing_acl';
 
@@ -39,11 +41,11 @@ class SharingACLMapper extends QBMapper {
 	}
 
 	/**
-	 * @param SharingACL $acl
-	 * @return SharingACL|Entity
+	 * @param SharingACL $sharingACL
+	 * @return SharingACL
 	 */
-	public function createACLEntry(SharingACL $acl) {
-		return $this->insert($acl);
+	public function createACLEntry(SharingACL $sharingACL): SharingACL {
+		return $this->insert($sharingACL);
 	}
 
 	/**
@@ -51,9 +53,9 @@ class SharingACLMapper extends QBMapper {
 	 *
 	 * @param string $user_id
 	 * @param string $vault_guid
-	 * @return Entity[]
+	 * @return SharingACL[]
 	 */
-	public function getVaultEntries(string $user_id, string $vault_guid) {
+	public function getVaultEntries(string $user_id, string $vault_guid): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -66,13 +68,13 @@ class SharingACLMapper extends QBMapper {
 	/**
 	 * Gets the acl for a given item guid
 	 *
-	 * @param string $user_id
+	 * @param string|null $user_id
 	 * @param string $item_guid
-	 * @return Entity
+	 * @return SharingACL
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getItemACL(?string $user_id, string $item_guid) {
+	public function getItemACL(?string $user_id, string $item_guid): SharingACL {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -91,9 +93,9 @@ class SharingACLMapper extends QBMapper {
 	 * Update an acl
 	 *
 	 * @param SharingACL $sharingACL
-	 * @return SharingACL|Entity
+	 * @return SharingACL
 	 */
-	public function updateCredentialACL(SharingACL $sharingACL) {
+	public function updateCredentialACL(SharingACL $sharingACL): SharingACL {
 		return $this->update($sharingACL);
 	}
 
@@ -101,9 +103,9 @@ class SharingACLMapper extends QBMapper {
 	 * Gets the currently accepted share requests from the given user for the given vault guid
 	 *
 	 * @param string $item_guid
-	 * @return Entity[]
+	 * @return SharingACL[]
 	 */
-	public function getCredentialAclList(string $item_guid) {
+	public function getCredentialAclList(string $item_guid): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -113,10 +115,10 @@ class SharingACLMapper extends QBMapper {
 	}
 
 	/**
-	 * @param SharingACL $ACL
-	 * @return SharingACL|Entity
+	 * @param SharingACL $sharingACL
+	 * @return SharingACL
 	 */
-	public function deleteShareACL(SharingACL $ACL) {
-		return $this->delete($ACL);
+	public function deleteShareACL(SharingACL $sharingACL): SharingACL {
+		return $this->delete($sharingACL);
 	}
 }

--- a/lib/Db/VaultMapper.php
+++ b/lib/Db/VaultMapper.php
@@ -25,12 +25,14 @@ namespace OCA\PassmanNext\Db;
 
 use OCA\PassmanNext\Utility\Utils;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Db\Entity;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
+/**
+ * @template-extends QBMapper<Vault>
+ */
 class VaultMapper extends QBMapper {
 	const TABLE_NAME = 'passman_vaults';
 
@@ -45,26 +47,26 @@ class VaultMapper extends QBMapper {
 	/**
 	 * @param int $vault_id
 	 * @param string $user_id
-	 * @return Entity[]
+	 * @return Vault
 	 */
-	public function find(int $vault_id, string $user_id) {
+	public function findById(int $vault_id, string $user_id): Vault {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($vault_id, IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('user_id', $qb->createNamedParameter($user_id, IQueryBuilder::PARAM_STR)));
 
-		return $this->findEntities($qb);
+		return $this->findEntity($qb);
 	}
 
 	/**
 	 * @param string $vault_guid
 	 * @param string $user_id
-	 * @return Entity
+	 * @return Vault
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function findByGuid(string $vault_guid, string $user_id) {
+	public function findByGuid(string $vault_guid, string $user_id): Vault {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -77,9 +79,9 @@ class VaultMapper extends QBMapper {
 
 	/**
 	 * @param string $user_id
-	 * @return Entity[]
+	 * @return Vault[]
 	 */
-	public function findVaultsFromUser(string $user_id) {
+	public function findVaultsFromUser(string $user_id): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
@@ -93,9 +95,9 @@ class VaultMapper extends QBMapper {
 	 *
 	 * @param string $vault_name
 	 * @param string $user_id
-	 * @return Vault|Entity
+	 * @return Vault
 	 */
-	public function create(string $vault_name, string $user_id) {
+	public function create(string $vault_name, string $user_id): Vault {
 		$vault = new Vault();
 		$vault->setName($vault_name);
 		$vault->setUserId($user_id);
@@ -110,9 +112,9 @@ class VaultMapper extends QBMapper {
 	 *
 	 * @param int $vault_id
 	 * @param string $user_id
-	 * @return Vault|Entity
+	 * @return Vault
 	 */
-	public function setLastAccess(int $vault_id, string $user_id) {
+	public function setLastAccess(int $vault_id, string $user_id): Vault {
 		$vault = new Vault();
 		$vault->setId($vault_id);
 		$vault->setUserId($user_id);
@@ -124,9 +126,9 @@ class VaultMapper extends QBMapper {
 	 * Update vault
 	 *
 	 * @param Vault $vault
-	 * @return Vault|Entity
+	 * @return Vault
 	 */
-	public function updateVault(Vault $vault) {
+	public function updateVault(Vault $vault): Vault {
 		return $this->update($vault);
 	}
 
@@ -136,9 +138,9 @@ class VaultMapper extends QBMapper {
 	 * @param int $vault_id
 	 * @param string $privateKey
 	 * @param string $publicKey
-	 * @return Vault|Entity
+	 * @return Vault
 	 */
-	public function updateSharingKeys(int $vault_id, string $privateKey, string $publicKey) {
+	public function updateSharingKeys(int $vault_id, string $privateKey, string $publicKey): Vault {
 		$vault = new Vault();
 		$vault->setId($vault_id);
 		$vault->setPrivateSharingKey($privateKey);
@@ -152,7 +154,7 @@ class VaultMapper extends QBMapper {
 	 *
 	 * @param Vault $vault
 	 */
-	public function deleteVault(Vault $vault) {
+	public function deleteVault(Vault $vault): void {
 		$this->delete($vault);
 	}
 }

--- a/lib/Db/VaultMapper.php
+++ b/lib/Db/VaultMapper.php
@@ -36,7 +36,7 @@ class VaultMapper extends QBMapper {
 
 	public function __construct(
 		IDBConnection $db,
-		private Utils $utils,
+		private readonly Utils $utils,
 	) {
 		parent::__construct($db, self::TABLE_NAME);
 	}

--- a/lib/Middleware/APIMiddleware.php
+++ b/lib/Middleware/APIMiddleware.php
@@ -10,7 +10,7 @@ use OCP\IRequest;
 class APIMiddleware extends Middleware {
 
 	public function __construct(
-		private IRequest $request,
+		private readonly IRequest $request,
 	) {
 	}
 

--- a/lib/Middleware/ShareMiddleware.php
+++ b/lib/Middleware/ShareMiddleware.php
@@ -10,11 +10,9 @@ use OCP\AppFramework\Middleware;
 
 class ShareMiddleware extends Middleware {
 
-	private $settings;
-
-	public function __construct(SettingsService $config) {
-		$this->settings = $config;
-	}
+	public function __construct(private readonly SettingsService $settings)
+    {
+    }
 
 
 	public function beforeController($controller, $methodName) {

--- a/lib/Migration/ServerSideEncryption.php
+++ b/lib/Migration/ServerSideEncryption.php
@@ -43,12 +43,12 @@ class ServerSideEncryption implements IRepairStep {
 	private $installedVersion;
 
 	public function __construct(
-		private EncryptService $encryptService,
-		private IDBConnection $db,
-		private LoggerInterface $logger,
-		private CredentialService $credentialService,
-		private CredentialRevisionService $revisionService,
-		private FileService $fileService,
+		private readonly EncryptService $encryptService,
+		private readonly IDBConnection $db,
+		private readonly LoggerInterface $logger,
+		private readonly CredentialService $credentialService,
+		private readonly CredentialRevisionService $revisionService,
+		private readonly FileService $fileService,
 		IConfig $config,
 	) {
 		$this->installedVersion = $config->getAppValue('passman', 'installed_version');

--- a/lib/Search/Provider.php
+++ b/lib/Search/Provider.php
@@ -72,22 +72,22 @@ class Provider implements IProvider {
 		$searchResultEntries = [];
 
 		if ($this->settings->getAppSetting('enable_global_search', 0) === 1) {
-			$VaultService = new VaultService(new VaultMapper($this->db, new Utils()));
-			$Vaults = $VaultService->getByUser($user->getUID());
-			$CredentialMapper = new CredentialMapper($this->db, new Utils());
+			$vaultService = new VaultService(new VaultMapper($this->db, new Utils()));
+			$vaults = $vaultService->getByUser($user->getUID());
+			$credentialMapper = new CredentialMapper($this->db, new Utils());
 
-			foreach ($Vaults as $Vault) {
+			foreach ($vaults as $vault) {
 				try {
-					$Credentials = $CredentialMapper->getCredentialsByVaultId($Vault->getId(), $Vault->getUserId());
+					$credentials = $credentialMapper->getCredentialsByVaultId($vault->getId(), $vault->getUserId());
 
-					foreach ($Credentials as $Credential) {
-						if (str_contains((string) $Credential->getLabel(), $query->getTerm())) {
+					foreach ($credentials as $credential) {
+						if (str_contains($credential->getLabel(), $query->getTerm())) {
 							try {
 								$searchResultEntries[] = new SearchResultEntry(
 									$this->urlGenerator->imagePath(Application::APP_ID, 'app.svg'),
-									$Credential->getLabel(),
-									\sprintf("Part of Passman vault %s", $Vault->getName()),
-									$this->urlGenerator->linkToRoute(Application::APP_ID . '.Page.index') . "#/vault/" . $Vault->getGuid() . "?show=" . $Credential->getGuid()
+									$credential->getLabel(),
+									\sprintf("Part of Passman vault %s", $vault->getName()),
+									$this->urlGenerator->linkToRoute(Application::APP_ID . '.Page.index') . "#/vault/" . $vault->getGuid() . "?show=" . $credential->getGuid()
 								);
 							} catch (\Exception) {
 							}

--- a/lib/Search/Provider.php
+++ b/lib/Search/Provider.php
@@ -43,10 +43,10 @@ use OCP\Search\SearchResultEntry;
 class Provider implements IProvider {
 
 	public function __construct(
-		private IL10N $l10n,
-		private IURLGenerator $urlGenerator,
-		private IDBConnection $db,
-		private SettingsService $settings,
+		private readonly IL10N $l10n,
+		private readonly IURLGenerator $urlGenerator,
+		private readonly IDBConnection $db,
+		private readonly SettingsService $settings,
 	) {
 
 	}
@@ -60,7 +60,7 @@ class Provider implements IProvider {
 	}
 
 	public function getOrder(string $route, array $routeParameters): int {
-		if (strpos($route, Application::APP_ID . '.') === 0) {
+		if (str_starts_with($route, Application::APP_ID . '.')) {
 			// Active app, prefer my results
 			return -1;
 		}
@@ -81,7 +81,7 @@ class Provider implements IProvider {
 					$Credentials = $CredentialMapper->getCredentialsByVaultId($Vault->getId(), $Vault->getUserId());
 
 					foreach ($Credentials as $Credential) {
-						if (strpos($Credential->getLabel(), $query->getTerm()) !== false) {
+						if (str_contains((string) $Credential->getLabel(), $query->getTerm())) {
 							try {
 								$searchResultEntries[] = new SearchResultEntry(
 									$this->urlGenerator->imagePath(Application::APP_ID, 'app.svg'),
@@ -89,12 +89,11 @@ class Provider implements IProvider {
 									\sprintf("Part of Passman vault %s", $Vault->getName()),
 									$this->urlGenerator->linkToRoute(Application::APP_ID . '.Page.index') . "#/vault/" . $Vault->getGuid() . "?show=" . $Credential->getGuid()
 								);
-							} catch (\Exception $e) {
+							} catch (\Exception) {
 							}
 						}
 					}
-				} catch (DoesNotExistException $e) {
-				} catch (MultipleObjectsReturnedException $e) {
+				} catch (DoesNotExistException|MultipleObjectsReturnedException) {
 				}
 			}
 		}

--- a/lib/Service/CredentialRevisionService.php
+++ b/lib/Service/CredentialRevisionService.php
@@ -36,8 +36,8 @@ class CredentialRevisionService {
 	private $server_key;
 
 	public function __construct(
-		private CredentialRevisionMapper $credentialRevisionMapper,
-		private EncryptService $encryptService,
+		private readonly CredentialRevisionMapper $credentialRevisionMapper,
+		private readonly EncryptService $encryptService,
 		IConfig $config,
 	) {
 		$this->server_key = $config->getSystemValue('passwordsalt', '');

--- a/lib/Service/CredentialRevisionService.php
+++ b/lib/Service/CredentialRevisionService.php
@@ -65,7 +65,7 @@ class CredentialRevisionService {
 	 * @return CredentialRevision[] array with the json optimized ("serialized") versions of CredentialRevision
 	 * @throws \Exception
 	 */
-	public function getRevisions(int $credential_id, string $user_id = null): array {
+	public function getRevisions(int $credential_id, ?string $user_id = null): array {
 		$result = [];
 		$revisions = $this->credentialRevisionMapper->getRevisions($credential_id, $user_id);
 		foreach ($revisions as $revision) {
@@ -85,7 +85,7 @@ class CredentialRevisionService {
 	 * @throws MultipleObjectsReturnedException
 	 * @throws \Exception
 	 */
-	public function getRevision(int $credential_id, string $user_id = null): CredentialRevision {
+	public function getRevision(int $credential_id, ?string $user_id = null): CredentialRevision {
 		$revision = $this->credentialRevisionMapper->getRevision($credential_id, $user_id);
 		$c = json_decode(base64_decode($revision->getCredentialData()), true);
 		$revision->setCredentialData($this->encryptService->decryptCredential($c));

--- a/lib/Service/CredentialRevisionService.php
+++ b/lib/Service/CredentialRevisionService.php
@@ -26,7 +26,6 @@ namespace OCA\PassmanNext\Service;
 use OCA\PassmanNext\Db\CredentialRevision;
 use OCA\PassmanNext\Db\CredentialRevisionMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Db\Entity;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\IConfig;
 
@@ -53,7 +52,7 @@ class CredentialRevisionService {
 	 * @return CredentialRevision
 	 * @throws \Exception
 	 */
-	public function createRevision($credential, $userId, $credential_id, $edited_by) {
+	public function createRevision($credential, $userId, $credential_id, $edited_by): CredentialRevision {
 		$credential = $this->encryptService->encryptCredential($credential);
 		return $this->credentialRevisionMapper->create($credential, $userId, $credential_id, $edited_by);
 	}
@@ -63,15 +62,17 @@ class CredentialRevisionService {
 	 *
 	 * @param int $credential_id
 	 * @param string|null $user_id
-	 * @return Entity[]
+	 * @return CredentialRevision[] array with the json optimized ("serialized") versions of CredentialRevision
 	 * @throws \Exception
 	 */
-	public function getRevisions(int $credential_id, string $user_id = null) {
-		$result = $this->credentialRevisionMapper->getRevisions($credential_id, $user_id);
-		foreach ($result as $index => $revision) {
+	public function getRevisions(int $credential_id, string $user_id = null): array {
+		$result = [];
+		$revisions = $this->credentialRevisionMapper->getRevisions($credential_id, $user_id);
+		foreach ($revisions as $revision) {
 			$c = json_decode(base64_decode($revision->getCredentialData()), true);
-			$result[$index] = $revision->jsonSerialize();
-			$result[$index]['credential_data'] = $this->encryptService->decryptCredential($c);
+			$serializedRevision = $revision->jsonSerialize();
+			$serializedRevision['credential_data'] = $this->encryptService->decryptCredential($c);
+			$result[] = $serializedRevision;
 		}
 		return $result;
 	}
@@ -79,12 +80,12 @@ class CredentialRevisionService {
 	/**
 	 * @param int $credential_id
 	 * @param string|null $user_id
-	 * @return Entity
+	 * @return CredentialRevision
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 * @throws \Exception
 	 */
-	public function getRevision(int $credential_id, string $user_id = null) {
+	public function getRevision(int $credential_id, string $user_id = null): CredentialRevision {
 		$revision = $this->credentialRevisionMapper->getRevision($credential_id, $user_id);
 		$c = json_decode(base64_decode($revision->getCredentialData()), true);
 		$revision->setCredentialData($this->encryptService->decryptCredential($c));
@@ -98,7 +99,7 @@ class CredentialRevisionService {
 	 * @param string $user_id
 	 * @return CredentialRevision
 	 */
-	public function deleteRevision(int $revision_id, string $user_id) {
+	public function deleteRevision(int $revision_id, string $user_id): CredentialRevision {
 		return $this->credentialRevisionMapper->deleteRevision($revision_id, $user_id);
 	}
 
@@ -106,10 +107,10 @@ class CredentialRevisionService {
 	 * Update revision
 	 *
 	 * @param CredentialRevision $credentialRevision
-	 * @return CredentialRevision|Entity
+	 * @return CredentialRevision
 	 * @throws \Exception
 	 */
-	public function updateRevision(CredentialRevision $credentialRevision) {
+	public function updateRevision(CredentialRevision $credentialRevision): CredentialRevision {
 		$credential_data = $credentialRevision->getCredentialData();
 		$credential_data = json_decode(base64_decode($credential_data), true);
 		$credential_data = base64_encode(json_encode($this->encryptService->encryptCredential($credential_data)));

--- a/lib/Service/CredentialService.php
+++ b/lib/Service/CredentialService.php
@@ -30,8 +30,8 @@ use OCA\PassmanNext\Db\CredentialMapper;
 use OCA\PassmanNext\Db\SharingACL;
 use OCA\PassmanNext\Db\SharingACLMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Db\Entity;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
+use OCP\DB\Exception;
 use OCP\IConfig;
 use OCP\IURLGenerator;
 
@@ -62,7 +62,7 @@ class CredentialService {
 	 * @return Credential
 	 * @throws \Exception
 	 */
-	public function createCredential(array $credential) {
+	public function createCredential(array $credential): Credential {
 		$credential = $this->encryptService->encryptCredential($credential);
 		return $this->credentialMapper->create($credential);
 	}
@@ -71,25 +71,26 @@ class CredentialService {
 	 * Update credential
 	 *
 	 * @param array $credential
-	 * @param false $useRawUser
-	 * @return Credential|Entity
+	 * @param bool $useRawUser
+	 * @return Credential
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function updateCredential(array $credential, $useRawUser = false) {
-		$credential = $this->encryptService->encryptCredential($credential);
-		return $this->credentialMapper->updateCredential($credential, $useRawUser);
+	public function updateCredential(array $credential, bool $useRawUser = false): Credential {
+		$encryptedCredentialData = $this->encryptService->encryptCredential($credential);
+		return $this->credentialMapper->updateCredential((array) $encryptedCredentialData, $useRawUser);
 	}
 
 	/**
-	 * Update credential
+	 * Update credential based on its model/entity.
+	 * Usually only for internal processing.
 	 *
 	 * @param Credential $credential
-	 * @return Credential|Entity
+	 * @return Credential
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function upd(Credential $credential) {
+	public function updateCredentialEntity(Credential $credential): Credential {
 		$credential = $this->encryptService->encryptCredential($credential);
 		return $this->credentialMapper->updateCredential($credential->jsonSerialize(), false);
 	}
@@ -98,19 +99,21 @@ class CredentialService {
 	 * Delete credential
 	 *
 	 * @param Credential $credential
-	 * @return Entity
+	 * @return Credential
 	 */
-	public function deleteCredential(Credential $credential) {
+	public function deleteCredential(Credential $credential): Credential {
 		$this->shareService->unshareCredential($credential->getGuid());
 		return $this->credentialMapper->deleteCredential($credential);
 	}
 
 	/**
 	 * Delete leftovers from a credential
+	 *
 	 * @param Credential $credential
+	 * @param string $userId
 	 * @throws \Exception
 	 */
-	public function deleteCredentialParts(Credential $credential, $userId) {
+	public function deleteCredentialParts(Credential $credential, string $userId): void {
 		$this->activityService->add(
 			'item_destroyed_self', [$credential->getLabel()],
 			'', [],
@@ -130,10 +133,10 @@ class CredentialService {
 	 *
 	 * @param int $vault_id
 	 * @param string $user_id
-	 * @return Entity[]
+	 * @return Credential[]
 	 * @throws \Exception
 	 */
-	public function getCredentialsByVaultId(int $vault_id, string $user_id) {
+	public function getCredentialsByVaultId(int $vault_id, string $user_id): array {
 		$credentials = $this->credentialMapper->getCredentialsByVaultId($vault_id, $user_id);
 		foreach ($credentials as $index => $credential) {
 			$credentials[$index] = $this->encryptService->decryptCredential($credential);
@@ -146,24 +149,22 @@ class CredentialService {
 	 *
 	 * @param int $vault_id
 	 * @param string $user_id
-	 * @return mixed
+	 * @return Credential
+	 * @throws Exception
 	 */
-	public function getRandomCredentialByVaultId(int $vault_id, string $user_id) {
-		$credentials = $this->credentialMapper->getRandomCredentialByVaultId($vault_id, $user_id);
-		foreach ($credentials as $index => $credential) {
-			$credentials[$index] = $this->encryptService->decryptCredential($credential);
-		}
-		return array_pop($credentials);
+	public function getRandomCredentialByVaultId(int $vault_id, string $user_id): Credential {
+		$credential = $this->credentialMapper->getRandomCredentialByVaultId($vault_id, $user_id);
+		return $this->encryptService->decryptCredential($credential);
 	}
 
 	/**
 	 * Get expired credentials.
 	 *
 	 * @param int $timestamp
-	 * @return Entity[]
+	 * @return Credential[]
 	 * @throws \Exception
 	 */
-	public function getExpiredCredentials(int $timestamp) {
+	public function getExpiredCredentials(int $timestamp): array {
 		$credentials = $this->credentialMapper->getExpiredCredentials($timestamp);
 		foreach ($credentials as $index => $credential) {
 			$credentials[$index] = $this->encryptService->decryptCredential($credential);
@@ -175,12 +176,12 @@ class CredentialService {
 	 * Get a single credential.
 	 *
 	 * @param int $credential_id
-	 * @param string $user_id
-	 * @return array|Credential
+	 * @param string|null $user_id
+	 * @return Credential
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getCredentialById(int $credential_id, ?string $user_id) {
+	public function getCredentialById(int $credential_id, ?string $user_id): Credential {
 		$credential = $this->credentialMapper->getCredentialById($credential_id);
 		if ($credential->getUserId() === $user_id) {
 			return $this->encryptService->decryptCredential($credential);
@@ -210,13 +211,13 @@ class CredentialService {
 	 * Get credential label by credential id.
 	 *
 	 * @param int $credential_id
-	 * @return array|Credential
+	 * @return Credential partial Credential, containing only 'id' and 'label'
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getCredentialLabelById(int $credential_id) {
-		$credential = $this->credentialMapper->getCredentialLabelById($credential_id);
-		return $this->encryptService->decryptCredential($credential);
+	public function getCredentialLabelById(int $credential_id): Credential {
+		$partialCredential = $this->credentialMapper->getCredentialLabelById($credential_id);
+		return $this->encryptService->decryptCredential($partialCredential);
 	}
 
 	/**
@@ -224,21 +225,21 @@ class CredentialService {
 	 *
 	 * @param string $credential_guid
 	 * @param string|null $user_id
-	 * @return array|Credential
+	 * @return Credential
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getCredentialByGUID(string $credential_guid, string $user_id = null) {
+	public function getCredentialByGUID(string $credential_guid, string $user_id = null): Credential {
 		$credential = $this->credentialMapper->getCredentialByGUID($credential_guid, $user_id);
 		return $this->encryptService->decryptCredential($credential);
 	}
 
 	public function getDirectEditLink(Credential $credential): string {
-		$vaults = $this->vaultService->getById($credential->getVaultId(), $credential->getUserId());
+		$vault = $this->vaultService->getById($credential->getVaultId(), $credential->getUserId());
 		return $this->urlGenerator->getAbsoluteURL(
 			$this->urlGenerator->linkTo(
 				'',
-				'index.php/apps/' . Application::APP_ID . '/#/vault/' . $vaults[0]->getGuid() . '/edit/' . $credential->getGuid()
+				'index.php/apps/' . Application::APP_ID . '/#/vault/' . $vault->getGuid() . '/edit/' . $credential->getGuid()
 			)
 		);
 	}

--- a/lib/Service/CredentialService.php
+++ b/lib/Service/CredentialService.php
@@ -229,7 +229,7 @@ class CredentialService {
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getCredentialByGUID(string $credential_guid, string $user_id = null): Credential {
+	public function getCredentialByGUID(string $credential_guid, ?string $user_id = null): Credential {
 		$credential = $this->credentialMapper->getCredentialByGUID($credential_guid, $user_id);
 		return $this->encryptService->decryptCredential($credential);
 	}

--- a/lib/Service/CredentialService.php
+++ b/lib/Service/CredentialService.php
@@ -41,15 +41,15 @@ class CredentialService {
 	private $server_key;
 
 	public function __construct(
-		private CredentialMapper          $credentialMapper,
-		private SharingACLMapper          $sharingACL,
-		private ActivityService           $activityService,
-		private ShareService              $shareService,
-		private EncryptService            $encryptService,
-		private CredentialRevisionService $credentialRevisionService,
-		private IURLGenerator             $urlGenerator,
-		private VaultService              $vaultService,
-		private NotificationService       $notificationService,
+		private readonly CredentialMapper          $credentialMapper,
+		private readonly SharingACLMapper          $sharingACL,
+		private readonly ActivityService           $activityService,
+		private readonly ShareService              $shareService,
+		private readonly EncryptService            $encryptService,
+		private readonly CredentialRevisionService $credentialRevisionService,
+		private readonly IURLGenerator             $urlGenerator,
+		private readonly VaultService              $vaultService,
+		private readonly NotificationService       $notificationService,
 		IConfig                           $config,
 	) {
 		$this->server_key = $config->getSystemValue('passwordsalt', '');

--- a/lib/Service/CronService.php
+++ b/lib/Service/CronService.php
@@ -32,11 +32,11 @@ use Psr\Log\LoggerInterface;
 class CronService {
 
 	public function __construct(
-		private CredentialService   $credentialService,
-		private LoggerInterface     $logger,
-		private Utils               $utils,
-		private NotificationService $notificationService,
-		private ActivityService     $activityService,
+		private readonly CredentialService   $credentialService,
+		private readonly LoggerInterface     $logger,
+		private readonly Utils               $utils,
+		private readonly NotificationService $notificationService,
+		private readonly ActivityService     $activityService,
 	) {
 	}
 

--- a/lib/Service/DeleteVaultRequestService.php
+++ b/lib/Service/DeleteVaultRequestService.php
@@ -31,7 +31,7 @@ use OCP\AppFramework\Db\Entity;
 class DeleteVaultRequestService {
 
 	public function __construct(
-		private DeleteVaultRequestMapper $deleteVaultRequestMapper,
+		private readonly DeleteVaultRequestMapper $deleteVaultRequestMapper,
 	) {
 	}
 
@@ -63,7 +63,7 @@ class DeleteVaultRequestService {
 	public function getDeleteRequestForVault(string $vault_guid) {
 		try {
 			return $this->deleteVaultRequestMapper->getDeleteRequestsForVault($vault_guid);
-		} catch (\Exception $e) {
+		} catch (\Exception) {
 			return false;
 		}
 	}

--- a/lib/Service/DeleteVaultRequestService.php
+++ b/lib/Service/DeleteVaultRequestService.php
@@ -25,7 +25,6 @@ namespace OCA\PassmanNext\Service;
 
 use OCA\PassmanNext\Db\DeleteVaultRequest;
 use OCA\PassmanNext\Db\DeleteVaultRequestMapper;
-use OCP\AppFramework\Db\Entity;
 
 
 class DeleteVaultRequestService {
@@ -36,31 +35,31 @@ class DeleteVaultRequestService {
 	}
 
 	/**
-	 *  Create a new DeleteVaultRequest
+	 * Create a new DeleteVaultRequest
 	 *
 	 * @param $request DeleteVaultRequest
 	 * @return DeleteVaultRequest
 	 */
-	public function createRequest(DeleteVaultRequest $request) {
+	public function createRequest(DeleteVaultRequest $request): DeleteVaultRequest {
 		return $this->deleteVaultRequestMapper->insert($request);
 	}
 
 	/**
-	 * Create a new DeleteVaultRequest
+	 * Get all delete requests
 	 *
-	 * @return Entity[]
+	 * @return DeleteVaultRequest[]
 	 */
-	public function getDeleteRequests() {
+	public function getDeleteRequests(): array {
 		return $this->deleteVaultRequestMapper->getDeleteRequests();
 	}
 
 	/**
-	 *  Create a new DeleteVaultRequest
+	 * Get DeleteVaultRequest for a specific vault by its guid
 	 *
 	 * @param $vault_guid string The vault guid
-	 * @return bool | Entity
+	 * @return bool | DeleteVaultRequest
 	 */
-	public function getDeleteRequestForVault(string $vault_guid) {
+	public function getDeleteRequestForVault(string $vault_guid): DeleteVaultRequest|bool {
 		try {
 			return $this->deleteVaultRequestMapper->getDeleteRequestsForVault($vault_guid);
 		} catch (\Exception) {
@@ -69,11 +68,11 @@ class DeleteVaultRequestService {
 	}
 
 	/**
-	 *  Create a new DeleteVaultRequest
+	 *  Deletes the given DeleteVaultRequest
 	 *
 	 * @param $req DeleteVaultRequest
 	 */
-	public function removeDeleteRequestForVault(DeleteVaultRequest $req) {
+	public function removeDeleteRequestForVault(DeleteVaultRequest $req): void {
 		$this->deleteVaultRequestMapper->removeDeleteVaultRequest($req);
 	}
 }

--- a/lib/Service/EncryptService.php
+++ b/lib/Service/EncryptService.php
@@ -132,13 +132,13 @@ class EncryptService {
 	/**
 	 * Decrypt the data with the provided key
 	 *
-	 * @param string $data_hex The encrypted datat to decrypt
+	 * @param string|null $data_hex The encrypted data to decrypt. Accept null for dynamic caller compatibility, but always return false then.
 	 * @param string $key The key to use for decryption
 	 *
 	 * @returns string|false The returned string if decryption is successful
 	 *                           false if it is not
 	 */
-	public function decrypt(string $data_hex, string $key): bool|string {
+	public function decrypt(?string $data_hex, string $key): bool|string {
 		if (!function_exists('hex2bin')) {
 			function hex2bin(string $str): string {
 				$sbin = "";
@@ -149,6 +149,9 @@ class EncryptService {
 
 				return $sbin;
 			}
+		}
+		if ($data_hex === null) {
+			return false;
 		}
 
 		$data = hex2bin($data_hex);

--- a/lib/Service/EncryptService.php
+++ b/lib/Service/EncryptService.php
@@ -28,7 +28,6 @@ namespace OCA\PassmanNext\Service;
 // Upgraded to use openssl
 use OCA\PassmanNext\Db\Credential;
 use OCA\PassmanNext\Db\File;
-use OCP\AppFramework\Db\Entity;
 use OCP\IConfig;
 
 /**
@@ -278,24 +277,24 @@ class EncryptService {
 
 
 	/**
-	 * Encrypt a credential
+	 * Decrypt a credential
 	 *
-	 * @param Credential|Entity|array $credential the credential to decrypt
-	 * @return Credential|array
+	 * @param Credential|array $credential the credential to decrypt
+	 * @return Credential|array modified $credential input object of the same type
 	 * @throws \Exception
 	 */
-	public function decryptCredential($credential) {
+	public function decryptCredential(Credential|array $credential): Credential|array {
 		return $this->handleCredential($credential, EncryptService::OP_DECRYPT);
 	}
 
 	/**
 	 * Encrypt a credential
 	 *
-	 * @param Credential|array $credential the credential to encrypt
-	 * @return Credential|array
+	 * @param array|Credential $credential the credential to encrypt
+	 * @return Credential|array modified $credential input object of the same type
 	 * @throws \Exception
 	 */
-	public function encryptCredential($credential) {
+	public function encryptCredential(Credential|array $credential): Credential|array {
 		return $this->handleCredential($credential, EncryptService::OP_ENCRYPT);
 	}
 
@@ -316,13 +315,14 @@ class EncryptService {
 	}
 
 	/**
-	 * Handles the encryption / decryption of a credential
+	 * Handles the encryption / decryption of a credential.
+	 * This modifies the $credential parameter object, slightly different based on the passed parameter type.
 	 *
 	 * @param Credential|array $credential the credential to encrypt
-	 * @return Credential|array
+	 * @return Credential|array modified $credential input object of the same type
 	 * @throws \Exception
 	 */
-	private function handleCredential($credential, $service_function) {
+	private function handleCredential(Credential|array $credential, $service_function): Credential|array {
 		[$userKey, $userSuppliedKey] = $this->extractKeysFromCredential($credential);
 
 		$key = static::makeKey($userKey, $this->server_key, $userSuppliedKey);
@@ -344,33 +344,34 @@ class EncryptService {
 	/**
 	 * Encrypt a file
 	 *
-	 * @param File|array $file
-	 * @return File|array
+	 * @param array|File $file
+	 * @return array|File modified $file input object of the same type
 	 * @throws \Exception
 	 */
-	public function encryptFile($file) {
+	public function encryptFile(array|File $file): array|File {
 		return $this->handleFile($file, EncryptService::OP_ENCRYPT);
 	}
 
 	/**
 	 * Decrypt a file
 	 *
-	 * @param File|Entity|array $file
-	 * @return array|File
+	 * @param array|File $file
+	 * @return array|File modified $file input object of the same type
 	 * @throws \Exception
 	 */
-	public function decryptFile($file) {
+	public function decryptFile(array|File $file): array|File {
 		return $this->handleFile($file, EncryptService::OP_DECRYPT);
 	}
 
 	/**
-	 * Handles the encryption / decryption of a File
+	 * Handles the encryption / decryption of a File.
+	 * This modifies the $file parameter object, slightly different based on the passed parameter type.
 	 *
-	 * @param File|array $file the credential to encrypt
-	 * @return File|array
+	 * @param array|File $file the file to encrypt/decrypt
+	 * @return array|File modified $file input object of the same type
 	 * @throws \Exception
 	 */
-	private function handleFile($file, $service_function) {
+	private function handleFile(array|File $file, $service_function): array|File {
 		$userKey = '';
 		$userSuppliedKey = '';
 		if ($file instanceof File) {

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -53,7 +53,7 @@ class FileService {
 	 * @throws MultipleObjectsReturnedException
 	 * @throws Exception
 	 */
-	public function getFile(int $fileId, string $userId = null): File {
+	public function getFile(int $fileId, ?string $userId = null): File {
 		$file = $this->fileMapper->getFile($fileId, $userId);
 		return $this->encryptService->decryptFile($file);
 	}
@@ -68,7 +68,7 @@ class FileService {
 	 * @throws MultipleObjectsReturnedException
 	 * @throws Exception
 	 */
-	public function getFileByGuid(string $file_guid, string $userId = null): File {
+	public function getFileByGuid(string $file_guid, ?string $userId = null): File {
 		$file = $this->fileMapper->getFileByGuid($file_guid, $userId);
 		return $this->encryptService->decryptFile($file);
 	}

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -27,7 +27,6 @@ use Exception;
 use OCA\PassmanNext\Db\File;
 use OCA\PassmanNext\Db\FileMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Db\Entity;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\IConfig;
 
@@ -49,12 +48,12 @@ class FileService {
 	 *
 	 * @param int $fileId
 	 * @param string|null $userId
-	 * @return array|File
+	 * @return File
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 * @throws Exception
 	 */
-	public function getFile(int $fileId, string $userId = null) {
+	public function getFile(int $fileId, string $userId = null): File {
 		$file = $this->fileMapper->getFile($fileId, $userId);
 		return $this->encryptService->decryptFile($file);
 	}
@@ -64,30 +63,30 @@ class FileService {
 	 *
 	 * @param string $file_guid
 	 * @param string|null $userId
-	 * @return array|File
+	 * @return File
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 * @throws Exception
 	 */
-	public function getFileByGuid(string $file_guid, string $userId = null) {
+	public function getFileByGuid(string $file_guid, string $userId = null): File {
 		$file = $this->fileMapper->getFileByGuid($file_guid, $userId);
 		return $this->encryptService->decryptFile($file);
 	}
 
 	/**
-	 * Upload a new file,
+	 * Upload a new file
 	 *
 	 * @param array $file
 	 * @param string $userId
-	 * @return array|File
+	 * @return File
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 * @throws Exception
 	 */
-	public function createFile(array $file, string $userId) {
+	public function createFile(array $file, string $userId): File {
 		$file = $this->encryptService->encryptFile($file);
-		$file = $this->fileMapper->create($file, $userId);
-		return $this->getFile($file->getId());
+		$fileEntity = $this->fileMapper->create($file, $userId);
+		return $this->getFile($fileEntity->getId());
 	}
 
 	/**
@@ -95,9 +94,9 @@ class FileService {
 	 *
 	 * @param int $file_id
 	 * @param string $userId
-	 * @return File|Entity
+	 * @return File
 	 */
-	public function deleteFile(int $file_id, string $userId) {
+	public function deleteFile(int $file_id, string $userId): File {
 		return $this->fileMapper->deleteFile($file_id, $userId);
 	}
 
@@ -108,7 +107,7 @@ class FileService {
 	 * @return File
 	 * @throws Exception
 	 */
-	public function updateFile(File $file) {
+	public function updateFile(File $file): File {
 		$file = $this->encryptService->encryptFile($file);
 		return $this->fileMapper->updateFile($file);
 	}
@@ -120,11 +119,11 @@ class FileService {
 	 * @return string[]
 	 * @throws Exception
 	 */
-	public function getFileGuidsFromUser(string $userId) {
-		$files = $this->fileMapper->getFileGuidsFromUser($userId);
+	public function getFileGuidsFromUser(string $userId): array {
+		$partialFiles = $this->fileMapper->getFileGuidsFromUser($userId);
 		$results = [];
-		foreach ($files as $fileGuid) {
-			$results[] = $fileGuid->getGuid();
+		foreach ($partialFiles as $partialFile) {
+			$results[] = $partialFile->getGuid();
 		}
 		return $results;
 	}

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -37,8 +37,8 @@ class FileService {
 	private $server_key;
 
 	public function __construct(
-		private FileMapper $fileMapper,
-		private EncryptService $encryptService,
+		private readonly FileMapper $fileMapper,
+		private readonly EncryptService $encryptService,
 		IConfig $config,
 	) {
 		$this->server_key = $config->getSystemValue('passwordsalt', '');

--- a/lib/Service/IconService.php
+++ b/lib/Service/IconService.php
@@ -104,7 +104,7 @@ class IconService {
 	 * @param array|null $options Optional settings
 	 * @param bool $auto Search & download favicon on instantiation
 	 */
-	public function __construct(string $url, array $options = null, bool $auto = true) {
+	public function __construct(string $url, ?array $options = null, bool $auto = true) {
 		if (empty($url)) {
 			throw new \InvalidArgumentException("url is empty");
 		}

--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -34,9 +34,9 @@ class NotificationService {
     public const APP_URL_PREFIX = 'index.php/apps/' . Application::APP_ID;
 
 	public function __construct(
-		private IManager $manager,
-		private IURLGenerator $urlGenerator,
-		private IDBConnection $db,
+		private readonly IManager $manager,
+		private readonly IURLGenerator $urlGenerator,
+		private readonly IDBConnection $db,
 	) {
 	}
 

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -28,8 +28,6 @@ use OCP\IConfig;
 
 class SettingsService {
 
-	private $userId;
-	private $appName;
 	public $settings;
 
 	private $numeric_settings = [
@@ -44,12 +42,10 @@ class SettingsService {
 	];
 
 	public function __construct(
-		$UserId,
-		private IConfig $config,
-		$AppName,
+		private $userId,
+		private readonly IConfig $config,
+		private $appName,
 	) {
-		$this->userId = $UserId;
-		$this->appName = $AppName;
 		$this->settings = [
 			'link_sharing_enabled' => intval($this->config->getAppValue('passman', 'link_sharing_enabled', 1)),
 			'user_sharing_enabled' => intval($this->config->getAppValue('passman', 'user_sharing_enabled', 1)),
@@ -82,7 +78,7 @@ class SettingsService {
 	 * @return mixed
 	 */
 	public function getAppSetting($key, $default_value = null) {
-		$value = ($this->settings[$key]) ? $this->settings[$key] : $this->config->getAppValue('passman', $key, $default_value);
+		$value = $this->settings[$key] ?: $this->config->getAppValue('passman', $key, $default_value);
 		if (in_array($key, $this->numeric_settings)) {
 			$value = intval($value);
 		}

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -39,12 +39,12 @@ use OCP\Notification\IManager;
 
 class ShareService {
 	public function __construct(
-		private SharingACLMapper $sharingACL,
-		private ShareRequestMapper $shareRequest,
-		private CredentialMapper $credential,
-		private CredentialRevisionService $revisions,
-		private EncryptService $encryptService,
-		private IManager $IManager,
+		private readonly SharingACLMapper $sharingACL,
+		private readonly ShareRequestMapper $shareRequest,
+		private readonly CredentialMapper $credential,
+		private readonly CredentialRevisionService $revisions,
+		private readonly EncryptService $encryptService,
+		private readonly IManager $IManager,
 	) {
 	}
 

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -25,16 +25,15 @@ namespace OCA\PassmanNext\Service;
 
 
 use OCA\PassmanNext\Db\CredentialMapper;
+use OCA\PassmanNext\Db\CredentialRevision;
 use OCA\PassmanNext\Db\ShareRequest;
 use OCA\PassmanNext\Db\ShareRequestMapper;
 use OCA\PassmanNext\Db\SharingACL;
 use OCA\PassmanNext\Db\SharingACLMapper;
 use OCA\PassmanNext\Utility\Utils;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Db\Entity;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\DB\Exception;
-use OCP\DB\IResult;
 use OCP\Notification\IManager;
 
 class ShareService {
@@ -83,10 +82,12 @@ class ShareService {
 
 	/**
 	 * @param SharingACL $acl
-	 * @return Entity
+	 * @return SharingACL
 	 */
-	public function createACLEntry(SharingACL $acl) {
-		if ($acl->getCreated() === null) $acl->setCreated((new \DateTime())->getTimestamp());
+	public function createACLEntry(SharingACL $acl): SharingACL {
+		if ($acl->getCreated() === null) {
+			$acl->setCreated((new \DateTime())->getTimestamp());
+		}
 		return $this->sharingACL->createACLEntry($acl);
 	}
 
@@ -100,7 +101,7 @@ class ShareService {
 	 * @throws Exception
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function applyShare(string $item_guid, string $target_vault_guid, string $final_shared_key) {
+	public function applyShare(string $item_guid, string $target_vault_guid, string $final_shared_key): void {
 		$request = $this->shareRequest->getRequestByItemAndVaultGuid($item_guid, $target_vault_guid);
 		$permissions = $request->getPermissions();
 
@@ -123,9 +124,9 @@ class ShareService {
 	 * Obtains pending requests for the given user ID
 	 *
 	 * @param string $user_id
-	 * @return Entity[]
+	 * @return SharingACL[]
 	 */
-	public function getUserPendingRequests(string $user_id) {
+	public function getUserPendingRequests(string $user_id): array {
 		return $this->shareRequest->getUserPendingRequests($user_id);
 	}
 
@@ -138,114 +139,126 @@ class ShareService {
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getSharedItems(string $user_id, string $vault_guid) {
-		$entries = $this->sharingACL->getVaultEntries($user_id, $vault_guid);
+	public function getSharedItems(string $user_id, string $vault_guid): array {
+		$acceptedVaultShareRequests = $this->sharingACL->getVaultEntries($user_id, $vault_guid);
 
 		$return = [];
-		foreach ($entries as $entry) {
-			// Check if the user can read the credential, probably unnecesary, but just to be sure
-			if (!$entry->hasPermission(SharingACL::READ)) continue;
-			$tmp = $entry->jsonSerialize();
-			$credential = $this->credential->getCredentialById($entry->getItemId());
-			$credential = $this->encryptService->decryptCredential($credential);
-			$tmp['credential_data'] = $credential->jsonSerialize();
-
-			if (!$entry->hasPermission(SharingACL::FILES)) unset($tmp['credential_data']['files']);
-			unset($tmp['credential_data']['shared_key']);
-			$return[] = $tmp;
+		foreach ($acceptedVaultShareRequests as $acceptedVaultShareRequest) {
+			$serializableVaultShareRequest = $this->prepareSharedItemForResponse($acceptedVaultShareRequest);
+			if (!empty($serializableVaultShareRequest)) {
+				$return[] = $serializableVaultShareRequest;
+			}
 		}
 		return $return;
 	}
 
 	/**
-	 * Gets the acl for a given item guid
+	 * Get shared credential (from a user)
 	 *
-	 * @param string $user_id
+	 * @param string|null $user_id
 	 * @param string $item_guid
-	 * @return Entity
+	 * @return array
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getACL(?string $user_id, string $item_guid) {
-		return $this->sharingACL->getItemACL($user_id, $item_guid);
+	public function getSharedItem(?string $user_id, string $item_guid): array {
+		$acl = $this->sharingACL->getItemACL($user_id, $item_guid);
+
+		$serializableItemACL = $this->prepareSharedItemForResponse($acl);
+		if (empty($serializableItemACL)) {
+			throw new DoesNotExistException("Item not found or wrong access level");
+		}
+		return $serializableItemACL;
 	}
 
 	/**
-	 * @param string $user_id
+	 * @throws MultipleObjectsReturnedException
+	 * @throws DoesNotExistException
+	 */
+	private function prepareSharedItemForResponse(SharingACL $sharingACL): array|null {
+		// Check if the user can read the credential, probably unnecessary, but just to be sure
+		if (!$sharingACL->hasPermission(SharingACL::READ)) {
+			return null;
+		}
+
+		$credential = $this->credential->getCredentialById($sharingACL->getItemId());
+		$credential = $this->encryptService->decryptCredential($credential);
+
+		$serializableSharingACL = $sharingACL->jsonSerialize();
+		$serializableSharingACL['credential_data'] = $credential->jsonSerialize();
+
+		if (!$sharingACL->hasPermission(SharingACL::FILES)) {
+			unset($serializableSharingACL['credential_data']['files']);
+		}
+		unset($serializableSharingACL['credential_data']['shared_key']);
+		return $serializableSharingACL;
+	}
+
+	/**
+	 * Gets the acl for a given item guid
+	 *
+	 * @param string|null $user_id
 	 * @param string $item_guid
-	 * @return array|mixed
+	 * @return SharingACL
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getSharedItem(?string $user_id, string $item_guid) {
-		$acl = $this->sharingACL->getItemACL($user_id, $item_guid);
-
-		// Check if the user can read the credential, probably unnecesary, but just to be sure
-		if (!$acl->hasPermission(SharingACL::READ)) throw new DoesNotExistException("Item not found or wrong access level");
-
-		$tmp = $acl->jsonSerialize();
-		$credential = $this->credential->getCredentialById($acl->getItemId());
-		$credential = $this->encryptService->decryptCredential($credential);
-
-		$tmp['credential_data'] = $credential->jsonSerialize();
-
-		if (!$acl->hasPermission(SharingACL::FILES)) unset($tmp['credential_data']['files']);
-		unset($tmp['credential_data']['shared_key']);
-
-		return $tmp;
+	public function getACL(?string $user_id, string $item_guid): SharingACL {
+		return $this->sharingACL->getItemACL($user_id, $item_guid);
 	}
 
 	/**
 	 * Gets history from the given item checking the user's permissions to access it
 	 *
-	 * @param string $user_id
+	 * @param string|null $user_id
 	 * @param string $item_guid
-	 * @return array|Entity[]
+	 * @return array|CredentialRevision[]
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
-	 * @throws \Exception
 	 */
-	public function getItemHistory(?string $user_id, string $item_guid) {
+	public function getItemHistory(?string $user_id, string $item_guid): array {
 		$acl = $this->sharingACL->getItemACL($user_id, $item_guid);
-		if (!$acl->hasPermission(SharingACL::READ | SharingACL::HISTORY)) return [];
+		if (!$acl->hasPermission(SharingACL::READ | SharingACL::HISTORY)) {
+			return [];
+		}
 
 		return $this->revisions->getRevisions($acl->getItemId());
 	}
 
 
 	/**
-	 * Deletes a share request by the item ID
+	 * Deletes a share request by the item id
 	 *
 	 * @param ShareRequest $request
-	 * @return int|IResult
+	 * @return int
 	 * @throws Exception
 	 */
-	public function cleanItemRequestsForUser(ShareRequest $request) {
+	public function cleanItemRequestsForUser(ShareRequest $request): int {
 		return $this->shareRequest->cleanItemRequestsForUser($request->getItemId(), $request->getTargetUserId());
 	}
 
 	/**
-	 * Get an share request by id
+	 * Get a share request by id
 	 *
 	 * @param int $id
-	 * @return Entity
+	 * @return ShareRequest
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getShareRequestById(int $id) {
+	public function getShareRequestById(int $id): ShareRequest {
 		return $this->shareRequest->getShareRequestById($id);
 	}
 
 	/**
-	 * Get an share request by $item_guid and $target_vault_guid
+	 * Get a share request by $item_guid and $target_vault_guid
 	 *
 	 * @param string $item_guid
 	 * @param string $target_vault_guid
-	 * @return Entity
+	 * @return ShareRequest
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getRequestByGuid(string $item_guid, string $target_vault_guid) {
+	public function getRequestByGuid(string $item_guid, string $target_vault_guid): ShareRequest {
 		return $this->shareRequest->getRequestByItemAndVaultGuid($item_guid, $target_vault_guid);
 	}
 
@@ -253,9 +266,9 @@ class ShareService {
 	 * Get the access control list by item guid
 	 *
 	 * @param string $item_guid
-	 * @return Entity[]
+	 * @return SharingACL[]
 	 */
-	public function getCredentialAclList(string $item_guid) {
+	public function getCredentialAclList(string $item_guid): array {
 		return $this->sharingACL->getCredentialAclList($item_guid);
 	}
 
@@ -264,31 +277,31 @@ class ShareService {
 	 *
 	 * @param string $user_id
 	 * @param string $vault_guid
-	 * @return Entity[]
+	 * @return SharingACL[]
 	 */
-	public function getVaultAclList(string $user_id, string $vault_guid) {
+	public function getVaultAclList(string $user_id, string $vault_guid): array {
 		return $this->sharingACL->getVaultEntries($user_id, $vault_guid);
 	}
 
 	/**
 	 * @param string $item_guid
-	 * @return Entity[]
+	 * @return ShareRequest[]
 	 * @throws Exception
 	 */
-	public function getCredentialPendingAclList(string $item_guid) {
+	public function getCredentialPendingAclList(string $item_guid): array {
 		return $this->shareRequest->getRequestsByItemGuid($item_guid);
 	}
 
 	/**
 	 * Gets the ACL on the credential for the user
 	 *
-	 * @param string $user_id
+	 * @param string|null $user_id
 	 * @param string $item_guid
-	 * @return Entity
+	 * @return SharingACL
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getCredentialAclForUser(?string $user_id, string $item_guid) {
+	public function getCredentialAclForUser(?string $user_id, string $item_guid): SharingACL {
 		return $this->sharingACL->getItemACL($user_id, $item_guid);
 	}
 
@@ -296,9 +309,9 @@ class ShareService {
 	 * Get pending share requests by guid
 	 *
 	 * @param string $item_guid
-	 * @return Entity[]
+	 * @return ShareRequest[]
 	 */
-	public function getShareRequestsByGuid(string $item_guid) {
+	public function getShareRequestsByGuid(string $item_guid): array {
 		return $this->shareRequest->getShareRequestsByItemGuid($item_guid);
 	}
 
@@ -308,27 +321,27 @@ class ShareService {
 	 * @param ShareRequest $request
 	 * @return ShareRequest
 	 */
-	public function deleteShareRequest(ShareRequest $request) {
+	public function deleteShareRequest(ShareRequest $request): ShareRequest {
 		return $this->shareRequest->deleteShareRequest($request);
 	}
 
 	/**
 	 * Delete ACL
 	 *
-	 * @param SharingACL|Entity $ACL
-	 * @return SharingACL|Entity
+	 * @param SharingACL $sharingACL
+	 * @return SharingACL
 	 */
-	public function deleteShareACL(SharingACL $ACL) {
-		return $this->sharingACL->deleteShareACL($ACL);
+	public function deleteShareACL(SharingACL $sharingACL): SharingACL {
+		return $this->sharingACL->deleteShareACL($sharingACL);
 	}
 
 	/**
 	 * Updates the given ACL entry
 	 *
 	 * @param SharingACL $sharingACL
-	 * @return SharingACL|Entity
+	 * @return SharingACL
 	 */
-	public function updateCredentialACL(SharingACL $sharingACL) {
+	public function updateCredentialACL(SharingACL $sharingACL): SharingACL {
 		return $this->sharingACL->updateCredentialACL($sharingACL);
 	}
 
@@ -336,7 +349,7 @@ class ShareService {
 	 * @param ShareRequest $shareRequest
 	 * @return ShareRequest
 	 */
-	public function updateCredentialShareRequest(ShareRequest $shareRequest) {
+	public function updateCredentialShareRequest(ShareRequest $shareRequest): ShareRequest {
 		return $this->shareRequest->updateShareRequest($shareRequest);
 	}
 
@@ -346,9 +359,9 @@ class ShareService {
 	 *
 	 * @param string $item_guid
 	 * @param string $user_id
-	 * @return Entity[]
+	 * @return ShareRequest[]
 	 */
-	public function getPendingShareRequestsForCredential(string $item_guid, string $user_id) {
+	public function getPendingShareRequestsForCredential(string $item_guid, string $user_id): array {
 		return $this->shareRequest->getPendingShareRequests($item_guid, $user_id);
 	}
 
@@ -356,10 +369,10 @@ class ShareService {
 	 * @param string $item_guid
 	 * @param string $user_id
 	 * @param int $permissions
-	 * @return int|IResult
+	 * @return int
 	 * @throws Exception
 	 */
-	public function updatePendingShareRequestsForCredential(string $item_guid, string $user_id, int $permissions) {
+	public function updatePendingShareRequestsForCredential(string $item_guid, string $user_id, int $permissions): int {
 		return $this->shareRequest->updatePendingRequestPermissions($item_guid, $user_id, $permissions);
 	}
 
@@ -368,7 +381,7 @@ class ShareService {
 	 * This will delete all ACL's and share requests.
 	 * @param string $item_guid
 	 */
-	public function unshareCredential(string $item_guid) {
+	public function unshareCredential(string $item_guid): void {
 		$acl_list = $this->getCredentialAclList($item_guid);
 		$request_list = $this->getShareRequestsByGuid($item_guid);
 		foreach ($acl_list as $ACL) {

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -293,19 +293,6 @@ class ShareService {
 	}
 
 	/**
-	 * Gets the ACL on the credential for the user
-	 *
-	 * @param string|null $user_id
-	 * @param string $item_guid
-	 * @return SharingACL
-	 * @throws DoesNotExistException
-	 * @throws MultipleObjectsReturnedException
-	 */
-	public function getCredentialAclForUser(?string $user_id, string $item_guid): SharingACL {
-		return $this->sharingACL->getItemACL($user_id, $item_guid);
-	}
-
-	/**
 	 * Get pending share requests by guid
 	 *
 	 * @param string $item_guid

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -43,7 +43,7 @@ class ShareService {
 		private readonly CredentialMapper $credential,
 		private readonly CredentialRevisionService $revisions,
 		private readonly EncryptService $encryptService,
-		private readonly IManager $IManager,
+		private readonly IManager $manager,
 	) {
 	}
 
@@ -389,11 +389,11 @@ class ShareService {
 		}
 		foreach ($request_list as $request) {
 			$this->deleteShareRequest($request);
-			$notification = $this->IManager->createNotification();
+			$notification = $this->manager->createNotification();
 			$notification->setApp('passman')
 				->setObject('passman_share_request', $request->getId())
 				->setUser($request->getTargetUserId());
-			$this->IManager->markProcessed($notification);
+			$this->manager->markProcessed($notification);
 		}
 	}
 }

--- a/lib/Service/VaultService.php
+++ b/lib/Service/VaultService.php
@@ -26,7 +26,6 @@ namespace OCA\PassmanNext\Service;
 use OCA\PassmanNext\Db\Vault;
 use OCA\PassmanNext\Db\VaultMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Db\Entity;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 
 
@@ -41,9 +40,9 @@ class VaultService {
 	/**
 	 * Get vaults from a user.
 	 * @param $userId
-	 * @return Entity[]
+	 * @return Vault[]
 	 */
-	public function getByUser($userId) {
+	public function getByUser($userId): array {
 		return $this->vaultMapper->findVaultsFromUser($userId);
 	}
 
@@ -51,21 +50,21 @@ class VaultService {
 	 * Get a single vault
 	 * @param $vault_id
 	 * @param $user_id
-	 * @return Entity[]
+	 * @return Vault
 	 */
-	public function getById($vault_id, $user_id) {
-		return $this->vaultMapper->find($vault_id, $user_id);
+	public function getById($vault_id, $user_id): Vault {
+		return $this->vaultMapper->findById($vault_id, $user_id);
 	}
 
 	/**
 	 * Get a single vault.
 	 * @param $vault_guid
 	 * @param $user_id
-	 * @return Entity
+	 * @return Vault
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function getByGuid($vault_guid, $user_id) {
+	public function getByGuid($vault_guid, $user_id): Vault {
 		return $this->vaultMapper->findByGuid($vault_guid, $user_id);
 	}
 
@@ -75,16 +74,16 @@ class VaultService {
 	 * @param $userId
 	 * @return Vault
 	 */
-	public function createVault($vault_name, $userId) {
+	public function createVault($vault_name, $userId): Vault {
 		return $this->vaultMapper->create($vault_name, $userId);
 	}
 
 	/**
 	 * Update vault
 	 * @param $vault
-	 * @return Vault|Entity
+	 * @return Vault
 	 */
-	public function updateVault($vault) {
+	public function updateVault($vault): Vault {
 		return $this->vaultMapper->updateVault($vault);
 	}
 
@@ -92,9 +91,9 @@ class VaultService {
 	 * Update last access time of a vault.
 	 * @param $vault_id
 	 * @param $user_id
-	 * @return Vault|Entity
+	 * @return Vault
 	 */
-	public function setLastAccess($vault_id, $user_id) {
+	public function setLastAccess($vault_id, $user_id): Vault {
 		return $this->vaultMapper->setLastAccess($vault_id, $user_id);
 	}
 
@@ -103,9 +102,9 @@ class VaultService {
 	 * @param $vault_id
 	 * @param $privateKey
 	 * @param $publicKey
-	 * @return Vault|Entity
+	 * @return Vault
 	 */
-	public function updateSharingKeys($vault_id, $privateKey, $publicKey) {
+	public function updateSharingKeys($vault_id, $privateKey, $publicKey): Vault {
 		return $this->vaultMapper->updateSharingKeys($vault_id, $privateKey, $publicKey);
 	}
 
@@ -116,10 +115,8 @@ class VaultService {
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function deleteVault($vault_guid, $user_id) {
+	public function deleteVault($vault_guid, $user_id): void {
 		$vault = $this->getByGuid($vault_guid, $user_id);
-		if ($vault instanceof Vault) {
-			$this->vaultMapper->deleteVault($vault);
-		}
+		$this->vaultMapper->deleteVault($vault);
 	}
 }

--- a/lib/Service/VaultService.php
+++ b/lib/Service/VaultService.php
@@ -33,7 +33,7 @@ use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 class VaultService {
 
 	public function __construct(
-		private VaultMapper $vaultMapper,
+		private readonly VaultMapper $vaultMapper,
 	) {
 
 	}

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -41,9 +41,9 @@ class Admin implements ISettings {
 	 */
 	public function __construct(
 		protected IConfig $config,
-		private IL10N $l,
-		private IAppManager $appManager,
-		private LoggerInterface $logger,
+		private readonly IL10N $l,
+		private readonly IAppManager $appManager,
+		private readonly LoggerInterface $logger,
 	) {
 	}
 

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -24,6 +24,7 @@
 namespace OCA\PassmanNext\Settings;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
@@ -66,8 +67,8 @@ class Admin implements ISettings {
 				$response = $httpClient->request('get', $url);
 				$json = $response->getBody()->getContents();
 
-				if ($json) {
-					$data = json_decode($json);
+				if (!empty($json)) {
+					$data = json_decode((string) $json);
 					if (isset($data->tag_name) && is_string($data->tag_name)) {
 						$githubVersion = $data->tag_name;
 
@@ -76,7 +77,7 @@ class Admin implements ISettings {
 						}
 					}
 				}
-			} catch (\Exception $e) {
+			} catch (\Exception|GuzzleException $e) {
 				$this->logger->error('Error fetching latest GitHub release version in lib/Admin:getForm()',
 					['exception' => $e->getTrace(), 'message' => $e->getMessage()]);
 			}

--- a/rector.php
+++ b/rector.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -9,14 +10,14 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 
 return RectorConfig::configure()
-    ->withPaths([
-        __DIR__ . '/appinfo',
-        __DIR__ . '/lib',
-        __DIR__ . '/templates',
-        __DIR__ . '/tests',
-    ])
-    ->withPhpSets(php84: true)
-    ->withTypeCoverageLevel(0)
+	->withPaths([
+		__DIR__ . '/appinfo',
+		__DIR__ . '/lib',
+		__DIR__ . '/templates',
+		__DIR__ . '/tests',
+	])
+	->withPhpSets(php84: true)
+	->withTypeCoverageLevel(0)
 	->withSkip([
 		// skip rule since it marks code that's intended, as it is
 		\Rector\Php70\Rector\FuncCall\RandomFunctionRector::class,

--- a/rector.php
+++ b/rector.php
@@ -15,5 +15,14 @@ return RectorConfig::configure()
         __DIR__ . '/templates',
         __DIR__ . '/tests',
     ])
-    ->withPhpSets(php81: true)
-    ->withTypeCoverageLevel(0);
+    ->withPhpSets(php84: true)
+    ->withTypeCoverageLevel(0)
+	->withSkip([
+		// skip rule since it marks code that's intended, as it is
+		\Rector\Php70\Rector\FuncCall\RandomFunctionRector::class,
+
+		// skip rule since it's introduced with php8.4 and not compatible to php8.1
+		\Rector\Php84\Rector\MethodCall\NewMethodCallWithoutParenthesesRector::class,
+		// skip rule since it's introduced with php8.3 and not compatible to php8.1
+		\Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector::class
+	]);

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/appinfo',
+        __DIR__ . '/lib',
+        __DIR__ . '/templates',
+        __DIR__ . '/tests',
+    ])
+    ->withPhpSets(php81: true)
+    ->withTypeCoverageLevel(0);

--- a/tests/db/DatabaseHelperTest.php
+++ b/tests/db/DatabaseHelperTest.php
@@ -80,12 +80,12 @@ abstract class DatabaseHelperTest extends PHPUnit_Extensions_Database_TestCase {
 		$this->db->executeQuery($this->db->getDatabasePlatform()->getTruncateTableSQL($table_name));
 	}
 
-	/**
-	 * Initializes the table with the corresponding dataset on the dumps dir
-	 *
-	 * @param $table_name
-	 */
-	public function setUpTable($table_name){
+    /**
+     * Initializes the table with the corresponding dataset on the dumps dir
+     *
+     * @param string $table_name
+     */
+	public function setUpTable(string $table_name){
 		$table = $this->getTableDataset($table_name);
 		$table_no_prefix = substr($table_name, 3);
 

--- a/tests/unit/controller/InternalControllerTest.php
+++ b/tests/unit/controller/InternalControllerTest.php
@@ -41,7 +41,7 @@ class InternalControllerTest extends PHPUnit_Framework_TestCase {
 	public function setUp() {
 		$request = $this->getMockBuilder('OCP\IRequest')->getMock();
 		$config = $this->getMockBuilder('OCP\IConfig')->getMock();
-		$this->credentialService = $this->getMockBuilder('OCA\PassmanNext\Service\CredentialService')
+		$this->credentialService = $this->getMockBuilder(\OCA\PassmanNext\Service\CredentialService::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->controller = new InternalController(

--- a/tests/unit/lib/BackgroundJob/ExpireCredentialsTest.php
+++ b/tests/unit/lib/BackgroundJob/ExpireCredentialsTest.php
@@ -46,7 +46,7 @@ class ExpireCredentialsTest extends PHPUnit_Framework_TestCase {
 		try {
 		    $backgroundJob->execute($jobList);
 		}
-		catch (Exception $ex) {
+		catch (Exception) {
 		    $this->assertTrue(false);
 		}
 	}

--- a/tests/unit/lib/Db/CredentialMapperTest.php
+++ b/tests/unit/lib/Db/CredentialMapperTest.php
@@ -106,8 +106,7 @@ class CredentialMapperTest extends DatabaseHelperTest {
 		$tmp = $this->filterDataset($tmp, 'id', $data[0]->getId());
 		$this->assertCount(count($tmp), $data);
 
-		$tmp[0] = Credential::fromRow($tmp[0]);
-		$this->assertEquals($tmp, $data);
+		$this->assertEquals(Credential::fromRow($tmp[0]), $data);
 	}
 
 	/**

--- a/tests/unit/lib/Service/IconServiceTest.php
+++ b/tests/unit/lib/Service/IconServiceTest.php
@@ -39,9 +39,9 @@ class IconServiceTest extends PHPUnit_Framework_TestCase {
 	private $testKey;
 
 	public function setUp() {
-		$this->options = array(
+		$this->options = [
 			'sslVerify' => false,
-		);
+		];
 
 	}
 


### PR DESCRIPTION
While trying to mitigate php8.4 deprecation warnings I ended in a comprehensive overhaul of our custom DB entity types and classes.
So we now have (almost everywhere) deterministic entity types from the controller to the entity class.

1. I've added and applied a [rector](https://github.com/rectorphp/rector) config for easier language migrations and php deprecation fixes
2. Migrated [implicit nullable parameters](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated) (deprecated since php8.4) to the explicit syntax introduced in php7.1; closes #834 
4. Improved type safety in custom QBMapper classes and its callers by using a more strict entity typing
5. Add .editorconfig to match Nextcloud's default file formatting when using an IDE like PhpStorm

---

original upstream pr: https://github.com/nextcloud/passman/pull/846